### PR TITLE
some access to Brick tables

### DIFF
--- a/trikControl/include/trikControl/brick.h
+++ b/trikControl/include/trikControl/brick.h
@@ -90,6 +90,9 @@ public slots:
 	/// Returns list of ports for sensors of a given type.
 	QStringList sensorPorts(Sensor::Type type) const;
 
+	/// Returns list of encoder ports
+	QStringList encoderPorts() const;
+
 	/// Returns reference to on-board accelerometer.
 	Sensor3d *accelerometer();
 

--- a/trikControl/src/brick.cpp
+++ b/trikControl/src/brick.cpp
@@ -277,6 +277,11 @@ Keys* Brick::keys()
 	return mKeys;
 }
 
+QStringList Brick::encoderPorts() const
+{
+	return mEncoders.keys();
+}
+
 Gamepad* Brick::gamepad()
 {
 	return mGamepad;


### PR DESCRIPTION
Чтоб не приходилось сначала получать QStringList портов, а потом бегать и смотреть, по каким из них !=  nullptr
