### PR TITLE
(trikControl) motors and encoders stores their port names

### DIFF
--- a/trikControl/include/trikControl/encoder.h
+++ b/trikControl/include/trikControl/encoder.h
@@ -31,7 +31,7 @@ public:
 	/// Constructor.
 	/// @param communicator - I2C communicator.
 	/// @param i2cCommandNumber - number of I2C command to query this encoder.
-	Encoder(I2cCommunicator &communicator, int i2cCommandNumber);
+	Encoder(I2cCommunicator &communicator, int i2cCommandNumber, QString const &port);
 
 public slots:
 	/// Returns current encoder reading.
@@ -40,8 +40,12 @@ public slots:
 	/// Resets encoder by setting current reading to 0.
 	void reset();
 
+	/// Returns name of host port
+	QString portName() const;
+
 private:
 	I2cCommunicator &mCommunicator;
+	QString mPort;
 	int mI2cCommandNumber;
 };
 

--- a/trikControl/include/trikControl/motor.h
+++ b/trikControl/include/trikControl/motor.h
@@ -45,6 +45,9 @@ public slots:
 	/// Turns off motor. This is not the same as setPower(0), because setPower will
 	/// leave motor on in a break mode, and this method will turn motor off.
 	virtual void powerOff() = 0;
+
+	/// Returns name of host port
+	virtual QString portName() const = 0;
 };
 
 }

--- a/trikControl/src/brick.cpp
+++ b/trikControl/src/brick.cpp
@@ -52,6 +52,7 @@ Brick::Brick(QThread &guiThread, QString const &configFilePath)
 				, mConfigurer->servoMotorPeriodFile(port)
 				, mConfigurer->servoMotorPeriod(port)
 				, mConfigurer->servoMotorInvert(port)
+				, port
 				);
 
 		mServoMotors.insert(port, servoMotor);
@@ -71,6 +72,7 @@ Brick::Brick(QThread &guiThread, QString const &configFilePath)
 				*mI2cCommunicator
 				, mConfigurer->powerMotorI2cCommandNumber(port)
 				, mConfigurer->powerMotorInvert(port)
+				, port
 				);
 
 		mPowerMotors.insert(port, powerMotor);
@@ -98,7 +100,7 @@ Brick::Brick(QThread &guiThread, QString const &configFilePath)
 	}
 
 	foreach (QString const &port, mConfigurer->encoderPorts()) {
-		Encoder *encoder = new Encoder(*mI2cCommunicator, mConfigurer->encoderI2cCommandNumber(port));
+		Encoder *encoder = new Encoder(*mI2cCommunicator, mConfigurer->encoderI2cCommandNumber(port), port);
 		mEncoders.insert(port, encoder);
 	}
 

--- a/trikControl/src/encoder.cpp
+++ b/trikControl/src/encoder.cpp
@@ -20,8 +20,9 @@ float const parToRad = 0.03272492;
 
 using namespace trikControl;
 
-Encoder::Encoder(I2cCommunicator &communicator, int i2cCommandNumber)
+Encoder::Encoder(I2cCommunicator &communicator, int i2cCommandNumber, QString const &port)
 	: mCommunicator(communicator)
+	, mPort(port)
 	, mI2cCommandNumber(i2cCommandNumber)
 {
 }
@@ -33,6 +34,11 @@ void Encoder::reset()
 	command[1] = static_cast<char>(0x00);
 
 	mCommunicator.send(command);
+}
+
+QString Encoder::portName() const
+{
+	return mPort;
 }
 
 float Encoder::read()

--- a/trikControl/src/powerMotor.cpp
+++ b/trikControl/src/powerMotor.cpp
@@ -20,8 +20,9 @@
 
 using namespace trikControl;
 
-PowerMotor::PowerMotor(I2cCommunicator &communicator, int i2cCommandNumber, bool invert)
+PowerMotor::PowerMotor(I2cCommunicator &communicator, int i2cCommandNumber, bool invert, QString const &port)
 	: mCommunicator(communicator)
+	, mPort(port)
 	, mI2cCommandNumber(i2cCommandNumber)
 	, mInvert(invert)
 	, mCurrentPower(0)
@@ -60,4 +61,9 @@ int PowerMotor::power() const
 void PowerMotor::powerOff()
 {
 	setPower(0);
+}
+
+QString PowerMotor::portName() const
+{
+	return mPort;
 }

--- a/trikControl/src/powerMotor.h
+++ b/trikControl/src/powerMotor.h
@@ -32,7 +32,7 @@ class PowerMotor : public Motor
 public:
 	/// Constructor.
 	/// @param invert - true, if power values set by setPower slot shall be negated before sent to motor.
-	PowerMotor(I2cCommunicator &communicator, int i2cCommandNumber, bool invert);
+	PowerMotor(I2cCommunicator &communicator, int i2cCommandNumber, bool invert, QString const &port);
 
 	/// Destructor.
 	~PowerMotor();
@@ -49,8 +49,12 @@ public slots:
 	/// leave motor on in a break mode, and this method will turn motor off.
 	void powerOff();
 
+	/// Returns name of host port
+	QString portName() const;
+
 private:
 	I2cCommunicator &mCommunicator;
+	QString mPort;
 	int const mI2cCommandNumber;
 	bool const mInvert;
 	int mCurrentPower;

--- a/trikControl/src/servoMotor.cpp
+++ b/trikControl/src/servoMotor.cpp
@@ -19,9 +19,10 @@
 using namespace trikControl;
 
 ServoMotor::ServoMotor(int min, int max, int zero, int stop, QString const &dutyFile, QString const &periodFile
-		, int period, bool invert)
+		, int period, bool invert, QString const &port)
 	: mDutyFile(dutyFile)
 	, mPeriodFile(periodFile)
+	, mPort(port)
 	, mPeriod(period)
 	, mFrequency(1000000000 / period)
 	, mCurrentDutyPercent(0)
@@ -97,4 +98,9 @@ void ServoMotor::powerOff()
 	mDutyFile.close();
 
 	mCurrentPower = 0;
+}
+
+QString ServoMotor::portName() const
+{
+	return mPort;
 }

--- a/trikControl/src/servoMotor.h
+++ b/trikControl/src/servoMotor.h
@@ -39,7 +39,7 @@ public:
 	/// @param period - value of period for setting while initialization
 	/// @param invert - true, if power values set by setPower slot shall be negated before sent to motor.
 	ServoMotor(int min, int max, int zero, int stop, QString const &dutyFile, QString const &periodFile, int period
-			, bool invert);
+			, bool invert, QString const &port);
 
 public slots:
 	/// Sets current motor power to specified value, 0 to stop motor.
@@ -59,9 +59,13 @@ public slots:
 	/// leave motor on in a break mode, and this method will turn motor off.
 	void powerOff();
 
+	/// Returns name of host port
+	QString portName() const;
+
 private:
 	QFile mDutyFile;
 	QFile mPeriodFile;
+	QString mPort;
 	int mPeriod;
 	int mFrequency;
 	int mCurrentDutyPercent;


### PR DESCRIPTION
Не уверен, что это необходимо.
Но я, например, это так использую: во время первого запуска программы сопоставляются силовые моторы с энкодерами.  Во время завершения программы я сохраняю в настройки соответствие портов моторов и эккодеров, чтобы не делать повторно инициализацию при следующем запуске
