### PR TITLE
Lock-free read for gyro & accel.

### DIFF
--- a/trikControl/src/sensor3dWorker.h
+++ b/trikControl/src/sensor3dWorker.h
@@ -48,7 +48,10 @@ private slots:
 
 private:
 	QScopedPointer<QSocketNotifier> mSocketNotifier;
+	
 	QVector<int> mReading;
+	QVector<int> mReadingUnsynced;
+	
 	int mDeviceFileDescriptor;
 	int mMax;
 	int mMin;


### PR DESCRIPTION
-10% sys CPU & -10% usr CPU in 'top'