### PR TITLE
Roll formula

### DIFF
--- a/trikControl/src/gyroSensor.h
+++ b/trikControl/src/gyroSensor.h
@@ -83,7 +83,7 @@ private:
 	template <typename T>
 	static T getRoll(const QQuaternion &q)
 	{
-		return std::asin(2 * q.scalar() * q.y() - 2 * q.x() * q.y());
+		return std::asin(2 * q.scalar() * q.y() - 2 * q.x() * q.z());
 	}
 
 	template <typename T>


### PR DESCRIPTION
Error in roll formula is fixed in accordance with https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Quaternion_to_Euler_Angles_Conversion