### PR TITLE
One more improvement for safety, because timer is created in script t…

### DIFF
--- a/trikScriptRunner/src/scriptExecutionControl.cpp
+++ b/trikScriptRunner/src/scriptExecutionControl.cpp
@@ -34,10 +34,10 @@ void ScriptExecutionControl::reset()
 	mInEventDrivenMode = false;
 	emit stopWaiting();
 	for (QTimer * const timer : mTimers) {
-		timer->stop();
+		QMetaObject::invokeMethod(timer, "stop", Qt::QueuedConnection);
+		timer->deleteLater();
 	}
 
-	qDeleteAll(mTimers);
 	mTimers.clear();
 }
 


### PR DESCRIPTION
…hread, so timer should be stopped in it. This fix also removes warnings about timer stopping from another thread