### PR TITLE
Add show method for pixel array drawing

### DIFF
--- a/trikControl/include/trikControl/displayInterface.h
+++ b/trikControl/include/trikControl/displayInterface.h
@@ -38,7 +38,7 @@ public slots:
 	///        supported formats, but .jpg, .png, .bmp, .gif are supported.
 	virtual void showImage(const QString &fileName) = 0;
 
-	virtual void show(const QVector<uint8_t> & array, int width, int height, const QString & format) = 0;
+	virtual void show(const QVector<uint8_t> &array, int width, int height, const QString &format) = 0;
 
 	/// Add a label to the specific position of the screen without redrawing it.
 	/// If there already is a label in these coordinates, its contents will be updated.

--- a/trikControl/include/trikControl/displayInterface.h
+++ b/trikControl/include/trikControl/displayInterface.h
@@ -38,6 +38,8 @@ public slots:
 	///        supported formats, but .jpg, .png, .bmp, .gif are supported.
 	virtual void showImage(const QString &fileName) = 0;
 
+	virtual void show(const QVector<uint8_t> & array, int width, int height, const QString & format) = 0;
+
 	/// Add a label to the specific position of the screen without redrawing it.
 	/// If there already is a label in these coordinates, its contents will be updated.
 	/// @param text - label text.

--- a/trikControl/include/trikControl/displayInterface.h
+++ b/trikControl/include/trikControl/displayInterface.h
@@ -38,7 +38,7 @@ public slots:
 	///        supported formats, but .jpg, .png, .bmp, .gif are supported.
 	virtual void showImage(const QString &fileName) = 0;
 
-	virtual void show(const QVector<uint8_t> &array, int width, int height, const QString &format) = 0;
+	virtual void show(const QVector<int32_t> &array, int width, int height, const QString &format) = 0;
 
 	/// Add a label to the specific position of the screen without redrawing it.
 	/// If there already is a label in these coordinates, its contents will be updated.

--- a/trikControl/src/display.cpp
+++ b/trikControl/src/display.cpp
@@ -59,9 +59,9 @@ void trikControl::Display::showImage(const QString &fileName)
 	QMetaObject::invokeMethod(mGuiWorker, "showImage", Q_ARG(QString, correctedFileName));
 }
 
-void trikControl::Display::show(const QVector<uint8_t> &array, int width, int height, const QString &format)
+void trikControl::Display::show(const QVector<int32_t> &array, int width, int height, const QString &format)
 {
-	QMetaObject::invokeMethod(mGuiWorker, "show", Q_ARG(QVector<uint8_t>, array)
+	QMetaObject::invokeMethod(mGuiWorker, "show", Q_ARG(QVector<int32_t>, array)
 							  , Q_ARG(int, width), Q_ARG(int, height), Q_ARG(QString, format));
 }
 

--- a/trikControl/src/display.cpp
+++ b/trikControl/src/display.cpp
@@ -59,6 +59,12 @@ void trikControl::Display::showImage(const QString &fileName)
 	QMetaObject::invokeMethod(mGuiWorker, "showImage", Q_ARG(QString, correctedFileName));
 }
 
+void trikControl::Display::show(const QVector<uint8_t> &array, int width, int height, const QString &format)
+{
+	QMetaObject::invokeMethod(mGuiWorker, "show", Q_ARG(QVector<uint8_t>, array)
+							  , Q_ARG(int, width), Q_ARG(int, height), Q_ARG(QString, format));
+}
+
 void trikControl::Display::addLabel(const QString &text, int x, int y)
 {
 	QMetaObject::invokeMethod(mGuiWorker, "addLabel", Q_ARG(QString, text), Q_ARG(int, x), Q_ARG(int, y));

--- a/trikControl/src/display.h
+++ b/trikControl/src/display.h
@@ -43,7 +43,7 @@ public slots:
 	void setBackground(const QString &color) override;
 	void showImage(const QString &fileName) override;
 
-	void show(const QVector<uint8_t> & array, int width, int height, const QString & format);
+	void show(const QVector<uint8_t> &array, int width, int height, const QString &format) override;
 
 	void addLabel(const QString &text, int x, int y) override;
 	void removeLabels() override;

--- a/trikControl/src/display.h
+++ b/trikControl/src/display.h
@@ -43,6 +43,8 @@ public slots:
 	void setBackground(const QString &color) override;
 	void showImage(const QString &fileName) override;
 
+	void show(const QVector<uint8_t> & array, int width, int height, const QString & format);
+
 	void addLabel(const QString &text, int x, int y) override;
 	void removeLabels() override;
 

--- a/trikControl/src/display.h
+++ b/trikControl/src/display.h
@@ -43,7 +43,7 @@ public slots:
 	void setBackground(const QString &color) override;
 	void showImage(const QString &fileName) override;
 
-	void show(const QVector<uint8_t> &array, int width, int height, const QString &format) override;
+	void show(const QVector<int32_t> &array, int width, int height, const QString &format) override;
 
 	void addLabel(const QString &text, int x, int y) override;
 	void removeLabels() override;

--- a/trikControl/src/guiWorker.cpp
+++ b/trikControl/src/guiWorker.cpp
@@ -36,6 +36,7 @@ GuiWorker::GuiWorker()
 
 void GuiWorker::init()
 {
+	qRegisterMetaType<QVector<int32_t>>("QVector<int32_t>");
 	mImageWidget.reset(new GraphicsWidget());
 	mImageWidget->setWindowState(Qt::WindowFullScreen);
 	mImageWidget->setWindowFlags(mImageWidget->windowFlags() | Qt::WindowStaysOnTopHint);
@@ -60,23 +61,23 @@ void GuiWorker::showImage(const QString &fileName)
 	repaintGraphicsWidget();
 }
 
-void GuiWorker::show(const QVector<uint8_t> &array, int width, int height, const QString &format)
+void GuiWorker::show(const QVector<int32_t> &array, int width, int height, const QString &format)
 {
 	QImage::Format fmt;
 	if (format == "rgb32") {
 		fmt = QImage::Format_RGB32;
-	} else if (format == "rgb888"){
+	} else if (format == "rgb888") {
 		fmt = QImage::Format_RGB888;
-	}
-	else if (format == "grayscale8") {
+	} else if (format == "grayscale8") {
 		fmt = QImage::Format_Grayscale8;
 	} else {
 		QLOG_ERROR() << format << "format is not supported";
 		return;
 	}
 
-	QPixmap pixmap(QPixmap::fromImage(QImage(array.data(), width, height, fmt)));
-	mImageWidget->setPixmap(pixmap);
+
+	QImage img(reinterpret_cast<const uchar *>(array.constData()), width, height, fmt);
+	mImageWidget->setPixmap(QPixmap::fromImage(img));
 
 	repaintGraphicsWidget();
 }

--- a/trikControl/src/guiWorker.cpp
+++ b/trikControl/src/guiWorker.cpp
@@ -60,7 +60,7 @@ void GuiWorker::showImage(const QString &fileName)
 	repaintGraphicsWidget();
 }
 
-void GuiWorker::show(const QVector<uint8_t> & array, int width, int height, const QString & format)
+void GuiWorker::show(const QVector<uint8_t> &array, int width, int height, const QString &format)
 {
 	QImage::Format fmt;
 	if (format == "rgb32") {
@@ -75,9 +75,7 @@ void GuiWorker::show(const QVector<uint8_t> & array, int width, int height, cons
 		return;
 	}
 
-	QImage img(array.data(), width, height, fmt);
-
-	QPixmap pixmap(QPixmap::fromImage(img));
+	QPixmap pixmap(QPixmap::fromImage(QImage(array.data(), width, height, fmt)));
 	mImageWidget->setPixmap(pixmap);
 
 	repaintGraphicsWidget();

--- a/trikControl/src/guiWorker.cpp
+++ b/trikControl/src/guiWorker.cpp
@@ -66,40 +66,34 @@ void GuiWorker::show(const QVector<int32_t> &array, int width, int height, const
 	auto *allData = static_cast<const uchar *>(static_cast<const void *>(array.data()));
 	QImage::Format fmt;
 	const uchar *rawData = nullptr;
-	int rawDataLength = 0;
+	QVector<uchar> formattedData(width * height * 3); // Reserve maximum possible size of arrays
 
 	if (format == "rgb32") {
 		fmt = QImage::Format_RGB32;
 		rawData = allData;
-		rawDataLength = array.length();
 	} else if (format == "rgb888") {
 		fmt = QImage::Format_RGB888;
 
-		QVector<uchar> formattedData(width * height * 3);
+		formattedData.resize(width * height * 3);
 		for (int i = 0; i < width * height * 3; i++) {
 			formattedData[i] = allData[i * 4];
 		}
 		rawData = formattedData.constData();
-		rawDataLength = formattedData.length();
 	} else if (format == "grayscale8") {
 		fmt = QImage::Format_Grayscale8;
 
-		QVector<uchar> formattedData(width * height);
+		formattedData.resize(width * height);
 		for (int i = 0; i < width * height; i++) {
 			formattedData[i] = allData[i * 4];
 		}
 		rawData = formattedData.constData();
-		rawDataLength = formattedData.length();
 	} else {
 		QLOG_ERROR() << format << "format is not supported";
 		return;
 	}
 
-	uchar *result = new uchar[rawDataLength];
-	std::copy(rawData, rawData + rawDataLength - 1, result);
-	QImage img(result, width, height, fmt);
-	img.save("result.jpg");
-	mImageWidget->setPixmap(QPixmap::fromImage(img));
+	QImage img(rawData, width, height, fmt);
+	mImageWidget->setPixmap(QPixmap::fromImage(std::move(img)));
 
 	repaintGraphicsWidget();
 }

--- a/trikControl/src/guiWorker.cpp
+++ b/trikControl/src/guiWorker.cpp
@@ -26,6 +26,8 @@
 
 #include <QtGui/QPixmap>
 
+#include "QsLog.h"
+
 using namespace trikControl;
 
 GuiWorker::GuiWorker()
@@ -55,6 +57,29 @@ void GuiWorker::showImage(const QString &fileName)
 	}
 
 	mImageWidget->setPixmap(mImagesCache[fileName]);
+	repaintGraphicsWidget();
+}
+
+void GuiWorker::show(const QVector<uint8_t> & array, int width, int height, const QString & format)
+{
+	QImage::Format fmt;
+	if (format == "rgb32") {
+		fmt = QImage::Format_RGB32;
+	} else if (format == "rgb888"){
+		fmt = QImage::Format_RGB888;
+	}
+	else if (format == "grayscale8") {
+		fmt = QImage::Format_Grayscale8;
+	} else {
+		QLOG_ERROR() << format << "format is not supported";
+		return;
+	}
+
+	QImage img(array.data(), width, height, fmt);
+
+	QPixmap pixmap(QPixmap::fromImage(img));
+	mImageWidget->setPixmap(pixmap);
+
 	repaintGraphicsWidget();
 }
 

--- a/trikControl/src/guiWorker.h
+++ b/trikControl/src/guiWorker.h
@@ -50,7 +50,7 @@ public slots:
 	/// for better performance.
 	void showImage(const QString &fileName);
 
-	void show(const QVector<uint8_t> &array, int width, int height, const QString &format);
+	void show(const QVector<int32_t> &array, int width, int height, const QString &format);
 
 	/// Add a label to the specific position of the screen without redrawing it.
 	/// If there already is a label in these coordinates, its contents will be updated.

--- a/trikControl/src/guiWorker.h
+++ b/trikControl/src/guiWorker.h
@@ -50,7 +50,7 @@ public slots:
 	/// for better performance.
 	void showImage(const QString &fileName);
 
-	void show(const QVector<uint8_t> & array, int width, int height, const QString & format);
+	void show(const QVector<uint8_t> &array, int width, int height, const QString &format);
 
 	/// Add a label to the specific position of the screen without redrawing it.
 	/// If there already is a label in these coordinates, its contents will be updated.

--- a/trikControl/src/guiWorker.h
+++ b/trikControl/src/guiWorker.h
@@ -50,6 +50,8 @@ public slots:
 	/// for better performance.
 	void showImage(const QString &fileName);
 
+	void show(const QVector<uint8_t> & array, int width, int height, const QString & format);
+
 	/// Add a label to the specific position of the screen without redrawing it.
 	/// If there already is a label in these coordinates, its contents will be updated.
 	/// @param text - label text.


### PR DESCRIPTION
Fix #316
Now it can be used like this:
```
//rgb32
var photo = getPhoto();
brick.display().show(photo, 160, 120, "rgb32");
script.wait(5000);

//rgb888
pic = []
photo = getPhoto();
l = photo.length;
for (i = 0; i < l; i++) {
	var p = photo[i];
	pic.push((p&0xff0000)>>16);
	pic.push((p&0xff00)>>8);
	pic.push((p&0xff));
}
brick.display().show(pic, 160, 120, "rgb888");
script.wait(5000);                            

//grayscale8                                   
pic = []                                      
photo = getPhoto();
l = photo.length;                             
for (i = 0; i < l; i++) {                     
        var p = photo[i];                     
        pic.push(((p&0xff0000)>>18) + ((p&0xff00)>>10) + ((p&0xff)>>2));                
}                                             
                                              
brick.display().show(pic, 160, 120, "grayscale8");
script.wait(5000);
``` 

Should be discussed with @iakov 