### PR TITLE
Dispatch custom message from gamepad port

### DIFF
--- a/trikControl/include/trikControl/gamepadInterface.h
+++ b/trikControl/include/trikControl/gamepadInterface.h
@@ -77,6 +77,10 @@ signals:
 	/// @param pressed - 1 if button was pressed, 0 if it was released.
 	void button(int button, int pressed);
 
+	/// Any custom message for simple extention via gamepad protocol/TCP port
+	/// `custom my message` is delivered as "my message"
+	void custom(const QString &s);
+
 	/// Emitted when a gamepad connects to robot. Note that robot may have several connected gamepads, and this signal
 	/// will be emitted only when the first gamepad connects to robot.
 	void connected();

--- a/trikControl/src/fifo.h
+++ b/trikControl/src/fifo.h
@@ -70,6 +70,9 @@ private:
 	/// Last line that was read from FIFO.
 	QString mCurrent;
 
+	/// Lock for mCurrent
+	mutable QReadWriteLock mCurrentLock;
+
 	/// State of a FIFO file as a device.
 	DeviceState mState;
 };

--- a/trikControl/src/gamepad.cpp
+++ b/trikControl/src/gamepad.cpp
@@ -173,12 +173,8 @@ void Gamepad::handleButton(int button, int pressed)
 	if (!tmr) {
 		tmr = new QTimer(this);
 		tmr->setInterval(500);
-		connect(
-				tmr
-				, SIGNAL(timeout())
-				, this
-				, SLOT(onButtonStateClearTimerTimeout())
-				);
+		tmr->setSingleShot(true);
+		connect(tmr, &QTimer::timeout, this, &Gamepad::onButtonStateClearTimerTimeout);
 	}
 
 	tmr->start();

--- a/trikControl/src/gamepad.cpp
+++ b/trikControl/src/gamepad.cpp
@@ -135,6 +135,8 @@ void Gamepad::onNewData(const QString &data)
 	} else if (commandName == "keepalive") {
 		const int waitForMs = cmd.at(1).trimmed().toInt();
 		handleKeepalive(waitForMs);
+	} else if (commandName == "custom") {
+		handleCustom(data.mid(commandName.length()).trimmed());
 	} else {
 		QLOG_ERROR() << "Gamepad: unknown command" << commandName;
 	}
@@ -191,6 +193,12 @@ void Gamepad::handleKeepalive(int waitForMs)
 	} else {
 		mKeepaliveTimer.start(waitForMs);
 	}
+}
+
+void Gamepad::handleCustom(const QString &message)
+{
+	mLastCustomMessage = message;
+	emit custom(message);
 }
 
 void Gamepad::onButtonStateClearTimerTimeout()

--- a/trikControl/src/gamepad.h
+++ b/trikControl/src/gamepad.h
@@ -86,6 +86,8 @@ private:
 
 	void handleKeepalive(int waitForMs);
 
+	void handleCustom(const QString &message);
+
 	Fifo mUnderlyingFifo;
 
 	QSet<int> mButtonWasPressed;
@@ -97,10 +99,12 @@ private:
 	QHash<int, QTimer*> mButtonStateClearTimers;
 
 	QHash<int, PadStatus> mPads;
-	int mWheelPercent = -101;
+	int mWheelPercent { -101 };
 
 	QTimer mKeepaliveTimer;
-	bool mConnected {false};
+	QString mLastCustomMessage;
+
+	bool mConnected { false };
 };
 
 }

--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -82,11 +82,14 @@ void PythonEngineWorker::init()
 	if (initCounter++ == 0) {
 		mProgramName = Py_DecodeLocale("trikPythonRuntime", nullptr);
 		Py_SetProgramName(mProgramName);
-		auto path = QProcessEnvironment::systemEnvironment().value("TRIK_PYTHONPATH");
+		constexpr auto varName = "TRIK_PYTHONPATH";
+		auto const &path = QProcessEnvironment::systemEnvironment().value(varName);
 		if (path.isEmpty()) {
-			constexpr auto e = "TRIK_PYTHONPATH must be set to correct value";
+			auto const &e = QString("%1 must be set to correct value").arg(varName);
 			QLOG_FATAL() << e;
 			throw trikKernel::InternalErrorException(e);
+		} else {
+			QLOG_INFO() << varName << ":" << path;
 		}
 
 		/// TODO: Must point to local .zip file


### PR DESCRIPTION
Useful for extensibility, when gamepad is used as a simple TCP interface
accessible from script.
Designed to work only in event-driven mode