### PR TITLE
Fix deadlocking after abort signal

### DIFF
--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -121,7 +121,10 @@ void PythonEngineWorker::init()
 		PythonQtGILScope _;
 		PythonQt::init(PythonQt::RedirectStdOut | PythonQt::PythonAlreadyInitialized);
 		connect(PythonQt::self(), &PythonQt::pythonStdErr, this, &PythonEngineWorker::updateErrorMessage);
-		connect(PythonQt::self(), &PythonQt::pythonStdOut, this, &PythonEngineWorker::textInStdOut);
+		connect(PythonQt::self(), &PythonQt::pythonStdOut, this, [this](const QString& str){
+			QTimer::singleShot(0, this, [this, str](){this->textInStdOut(str);});
+			mScriptExecutionControl->wait(0);
+		});
 		PythonQtRegisterListTemplateConverter(QVector, uint8_t)
 		PythonQt_QtAll::init();
 	}

--- a/trikScriptRunner/src/trikPythonRunner.cpp
+++ b/trikScriptRunner/src/trikPythonRunner.cpp
@@ -30,8 +30,7 @@ TrikPythonRunner::TrikPythonRunner(trikControl::BrickInterface &brick
 	mScriptEngineWorker->moveToThread(&mWorkerThread);
 	connect(&mWorkerThread, &QThread::finished, mScriptEngineWorker, &PythonEngineWorker::deleteLater);
 	connect(&mWorkerThread, &QThread::started, mScriptEngineWorker, &PythonEngineWorker::init);
-	connect(mScriptEngineWorker, &PythonEngineWorker::textInStdOut, this, &TrikPythonRunner::textInStdOut
-		, Qt::BlockingQueuedConnection);
+	connect(mScriptEngineWorker, &PythonEngineWorker::textInStdOut, this, &TrikPythonRunner::textInStdOut);
 	connect(mScriptEngineWorker, &PythonEngineWorker::completed, this, &TrikPythonRunner::completed);
 	connect(mScriptEngineWorker, &PythonEngineWorker::startedScript, this, &TrikPythonRunner::startedScript);
 	connect(mScriptEngineWorker, &PythonEngineWorker::startedDirectScript


### PR DESCRIPTION
Extension for #496 bug. Because when Python script stops with `while True`, trikGui goes to deadlock.