### PR TITLE
Fix show image 

### DIFF
--- a/trikControl/src/guiWorker.cpp
+++ b/trikControl/src/guiWorker.cpp
@@ -64,7 +64,7 @@ void GuiWorker::showImage(const QString &fileName)
 
 void GuiWorker::show(const QVector<int32_t> &array, int width, int height, const QString &format)
 {
-	QImage img = Utilities::imageFromBytes(array, width, height, format);
+	QImage img = Utilities::imageFromBytes(array, width, height, format).copy();
 	if (img.isNull())
 		return;
 

--- a/trikControl/src/guiWorker.cpp
+++ b/trikControl/src/guiWorker.cpp
@@ -64,7 +64,7 @@ void GuiWorker::showImage(const QString &fileName)
 
 void GuiWorker::show(const QVector<int32_t> &array, int width, int height, const QString &format)
 {
-	QImage img = Utilities::imageFromBytes(array, width, height, format).copy();
+	QImage img = Utilities::imageFromBytes(array, width, height, format);
 	if (img.isNull())
 		return;
 


### PR DESCRIPTION
 Если мы создаем массив для вывода show  в javascript, а не перезаписываем буфер, который нам вернул getPhoto, то на экран выводится всякий мусор. 