### PR TITLE
Fix for old JS scripts with absolute path in `include`

### DIFF
--- a/translations/fr/trikScriptRunner_fr.ts
+++ b/translations/fr/trikScriptRunner_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trikScriptRunner::ScriptEngineWorker</name>
     <message>
-        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+286"/>
+        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+287"/>
         <source>Line %1: %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/ru/trikScriptRunner_ru.ts
+++ b/translations/ru/trikScriptRunner_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trikScriptRunner::ScriptEngineWorker</name>
     <message>
-        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+286"/>
+        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+287"/>
         <source>Line %1: %2</source>
         <translation type="unfinished">Строка %1: %2</translation>
     </message>

--- a/trikScriptRunner/src/scriptEngineWorker.cpp
+++ b/trikScriptRunner/src/scriptEngineWorker.cpp
@@ -134,7 +134,8 @@ void ScriptEngineWorker::brickBeep()
 
 void ScriptEngineWorker::evalInclude(const QString &filename, QScriptEngine * const engine)
 {
-	evalExternalFile(mWorkingDirectory + filename, engine);
+	QFileInfo fi(mWorkingDirectory, filename);
+	evalExternalFile(fi.absoluteFilePath(), engine);
 }
 
 void ScriptEngineWorker::setWorkingDir(const QString &workingDir)

--- a/trikScriptRunner/src/scriptEngineWorker.h
+++ b/trikScriptRunner/src/scriptEngineWorker.h
@@ -19,6 +19,7 @@
 #include <QtCore/QString>
 #include <QtCore/QThread>
 #include <QtScript/QScriptEngine>
+#include <QtCore/QDir>
 
 #include <trikControl/brickInterface.h>
 #include <trikNetwork/mailboxInterface.h>
@@ -169,7 +170,7 @@ private:
 	/// behavior when programs are started and stopped actively.
 	QMutex mScriptStateMutex;
 
-	QString mWorkingDirectory;
+	QDir mWorkingDirectory;
 };
 
 }


### PR DESCRIPTION
Keep absolute path in `include`, but resolve relative path.