### PR TITLE
[WIP] Expose trik APIs as python modules

### DIFF
--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -109,10 +109,6 @@ void PythonEngineWorker::init()
 		Py_NoSiteFlag = 1;
 		Py_NoUserSiteDirectory = 1;
 
-		if (PyImport_AppendInittab("trik", trikPythonModuleInit) == -1) {
-			abort();
-		}
-
 		Py_Initialize();
 		PyEval_InitThreads(); // For Python < 3.7
 	}
@@ -189,11 +185,7 @@ bool PythonEngineWorker::initTrik()
 {
 	PythonQt_init_PyTrikControl(mMainContext);
 
-	trikPythonModuleSetObjects(&mBrick, mScriptExecutionControl.data(), mMailbox);
-
-	mMainContext.addObject("brick", &mBrick);
-	mMainContext.addObject("script_cpp", mScriptExecutionControl.data());
-	mMainContext.addObject("mailbox", mMailbox);
+	trikPythonModuleInit(&mBrick, mScriptExecutionControl.data(), mMailbox);
 
 	return evalSystemPy();
 }

--- a/trikScriptRunner/src/trikPythonModule.cpp
+++ b/trikScriptRunner/src/trikPythonModule.cpp
@@ -14,7 +14,6 @@
 
 #include "trikPythonModule.h"
 
-#include <Python.h>
 #include <PythonQt.h>
 #include <PythonQtConversion.h>
 

--- a/trikScriptRunner/src/trikPythonModule.cpp
+++ b/trikScriptRunner/src/trikPythonModule.cpp
@@ -1,0 +1,105 @@
+/* Copyright 2020 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "trikPythonModule.h"
+
+#include <Python.h>
+#include <PythonQt.h>
+#include <PythonQtConversion.h>
+
+#include <trikControl/brickInterface.h>
+#include <trikNetwork/mailboxInterface.h>
+
+#include "scriptExecutionControl.h"
+
+static trikControl::BrickInterface* gBrick;
+static trikScriptRunner::ScriptExecutionControl* gScript;
+static trikNetwork::MailboxInterface* gMailbox;
+
+void trikPythonModuleSetObjects(trikControl::BrickInterface* brick,
+	trikScriptRunner::ScriptExecutionControl* script, trikNetwork::MailboxInterface* mailbox)
+{
+	gBrick = brick;
+	gScript = script;
+	gMailbox = mailbox;
+}
+
+static PyObject* trik_get_native_brick(PyObject *self, PyObject* args)
+{
+	if (!PyArg_ParseTuple(args, ""))
+		return nullptr;
+
+	return PythonQtConv::QVariantToPyObject(QVariant::fromValue(gBrick));
+}
+
+static PyObject* trik_get_native_script(PyObject *self, PyObject* args)
+{
+	if (!PyArg_ParseTuple(args, ""))
+		return nullptr;
+
+	return PythonQtConv::QVariantToPyObject(QVariant::fromValue(gScript));
+}
+
+static PyObject* trik_get_native_mailbox(PyObject *self, PyObject* args)
+{
+	if (!PyArg_ParseTuple(args, ""))
+		return nullptr;
+
+	return PythonQtConv::QVariantToPyObject(QVariant::fromValue(gMailbox));
+}
+
+static PyMethodDef TrikMethods[] =
+{
+	{"_get_native_brick", trik_get_native_brick, METH_VARARGS, nullptr},
+	{"_get_native_script", trik_get_native_script, METH_VARARGS, nullptr},
+	{"_get_native_mailbox", trik_get_native_mailbox, METH_VARARGS, nullptr},
+	{nullptr, nullptr, 0, nullptr}        /* Sentinel */
+};
+
+static struct PyModuleDef trikmodule =
+{
+	PyModuleDef_HEAD_INIT,
+	"trik",   /* name of module */
+	nullptr, /* module documentation, may be nullptr */
+	-1,       /* size of per-interpreter state of the module,
+				 or -1 if the module keeps state in global variables. */
+	TrikMethods
+};
+
+PyMODINIT_FUNC trikPythonModuleInit()
+{
+	PythonQtObjectPtr mod = PyModule_Create(&trikmodule);
+
+	// make module a package
+	PyModule_AddStringConstant(mod, "__package__", "trik");
+	PyModule_AddObject(mod, "__path__", PyList_New(0));
+
+	PythonQtObjectPtr all_ptr = PyList_New((gMailbox != nullptr) ? 3 : 2);
+	PyList_SetItem(all_ptr, 0, PyString_FromString("brick"));
+	PyList_SetItem(all_ptr, 1, PyString_FromString("script"));
+	if (gMailbox != nullptr)
+		PyList_SetItem(all_ptr, 2, PyString_FromString("mailbox"));
+	PyModule_AddObject(mod, "__all__", all_ptr.takeObject());
+
+	mod.evalScript(	"_modules = __import__('sys').modules\n"
+					"brick = _modules['trik.brick'] = _get_native_brick()\n"
+					"script = _modules['trik.script'] = _get_native_script()\n"
+					"if _get_native_mailbox():\n  mailbox = _modules['trik.mailbox'] = _get_native_mailbox()\n"
+					"del _modules");
+
+	return mod;
+}
+
+
+

--- a/trikScriptRunner/src/trikPythonModule.h
+++ b/trikScriptRunner/src/trikPythonModule.h
@@ -1,0 +1,29 @@
+/* Copyright 2020 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <Python.h>
+
+#include <trikControl/brickInterface.h>
+#include <trikNetwork/mailboxInterface.h>
+
+#include "scriptExecutionControl.h"
+
+PyMODINIT_FUNC trikPythonModuleInit();
+PyMODINIT_FUNC trikBrickPythonModuleInit();
+PyMODINIT_FUNC trikScriptPythonModuleInit();
+PyMODINIT_FUNC trikMailboxPythonModuleInit();
+void trikPythonModuleSetObjects(trikControl::BrickInterface* brick,
+	trikScriptRunner::ScriptExecutionControl* script, trikNetwork::MailboxInterface* mailbox);

--- a/trikScriptRunner/src/trikPythonModule.h
+++ b/trikScriptRunner/src/trikPythonModule.h
@@ -21,9 +21,5 @@
 
 #include "scriptExecutionControl.h"
 
-PyMODINIT_FUNC trikPythonModuleInit();
-PyMODINIT_FUNC trikBrickPythonModuleInit();
-PyMODINIT_FUNC trikScriptPythonModuleInit();
-PyMODINIT_FUNC trikMailboxPythonModuleInit();
-void trikPythonModuleSetObjects(trikControl::BrickInterface* brick,
-	trikScriptRunner::ScriptExecutionControl* script, trikNetwork::MailboxInterface* mailbox);
+void trikPythonModuleInit(trikControl::BrickInterface* brick,
+			 trikScriptRunner::ScriptExecutionControl* script, trikNetwork::MailboxInterface* mailbox);

--- a/trikScriptRunner/src/trikPythonModule.h
+++ b/trikScriptRunner/src/trikPythonModule.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <Python.h>
+#include <PythonQt.h>
 
 #include <trikControl/brickInterface.h>
 #include <trikNetwork/mailboxInterface.h>

--- a/trikScriptRunner/system.py
+++ b/trikScriptRunner/system.py
@@ -15,6 +15,10 @@
 import os
 import types
 
+from trik import *
+
+script_cpp = script
+
 script = types.SimpleNamespace()
 script.random = script_cpp.random
 script.wait = script_cpp.wait
@@ -29,6 +33,8 @@ script.run = script_cpp.run
 script.quit = script_cpp.quit
 script.reset = script_cpp.reset
 script.getPhoto = script_cpp.getPhoto
+
+del script_cpp
 
 class KeysEnum():
     Left = 105

--- a/trikScriptRunner/trikScriptRunner.pro
+++ b/trikScriptRunner/trikScriptRunner.pro
@@ -30,10 +30,11 @@ HEADERS += \
 	$$PWD/src/threading.h \
 	$$PWD/src/utils.h \
 	$$PWD/src/scriptThread.h \
+	$$PWD/src/trikPythonModule.h \
 	$$PWD/include/trikScriptRunner/trikScriptRunnerInterface.h \
 	$$PWD/include/trikScriptRunner/trikPythonRunner.h \
 	$$PWD/include/trikScriptRunner/trikJavaScriptRunner.h \
-	$$PWD/include/trikScriptRunner/trikVariablesServer.h
+	$$PWD/include/trikScriptRunner/trikVariablesServer.h \
 
 SOURCES += \
 	$$PWD/src/scriptExecutionControl.cpp \
@@ -45,7 +46,8 @@ SOURCES += \
 	$$PWD/src/threading.cpp \
 	$$PWD/src/utils.cpp \
 	$$PWD/src/scriptThread.cpp \
-	$$PWD/src/trikVariablesServer.cpp
+	$$PWD/src/trikVariablesServer.cpp \
+	$$PWD/src/trikPythonModule.cpp
 
 OTHER_FILES += \
 	$$PWD/system.js \


### PR DESCRIPTION
This will allow to use the following statements:

```python3
import trik                  # trik.brick, trik.script and trik.mailbox can now be used
import trik.brick as brick   # imports brick into a global namespace
from trik import brick       # ditto
from trik import *           # imports brick, script and mailbox (if available) into global namespace
```

Allowing to do so makes easier to integrate with existing code completion tools by defining stub module definitions.

`brick`, `script` and `mailbox` are still introduced into the global namespace without any imports. Maybe this should be gotten rid of, as using those as is will break code completion tools. On the other hand, making imports mandatory will break compatibility with existing scripts.

Also changes how code is executed, propagating the source file name for the backtrace (not yet integrated with TS).