### PR TITLE
Fix trikGui crash and non-working keys

### DIFF
--- a/trikControl/src/eventDevice.cpp
+++ b/trikControl/src/eventDevice.cpp
@@ -27,6 +27,7 @@ EventDevice::EventDevice(const QString &eventFile, const trikHal::HardwareAbstra
 	mWorker.reset(new EventDeviceWorker(eventFile, mState, hardwareAbstraction));
 	if (!mState.isFailed()) {
 		mWorker->moveToThread(&mWorkerThread);
+		connect(&mWorkerThread, &QThread::started, mWorker.data(), &EventDeviceWorker::init);
 		connect(mWorker.data(), &EventDeviceWorker::newEvent, this, &EventDevice::on);
 
 		QLOG_INFO() << "Starting generic event device" << eventFile << " worker thread" << &mWorkerThread;

--- a/trikControl/src/eventDeviceWorker.cpp
+++ b/trikControl/src/eventDeviceWorker.cpp
@@ -22,11 +22,18 @@ using namespace trikControl;
 
 EventDeviceWorker::EventDeviceWorker(const QString &deviceFilePath, DeviceState &state
 		, const trikHal::HardwareAbstractionInterface &hardwareAbstraction)
-	: mEventFile(hardwareAbstraction.createEventFile(deviceFilePath))
+	: mState(state)
+	, mHardwareAbstraction(hardwareAbstraction)
+	, mEventFileName(deviceFilePath)
 {
-	state.start();
+	mState.start();
+}
+
+void EventDeviceWorker::init()
+{
+	mEventFile.reset(mHardwareAbstraction.createEventFile(mEventFileName));
 	if (!mEventFile->open()) {
-		state.fail();
+		mState.fail();
 		return;
 	}
 

--- a/trikControl/src/eventDeviceWorker.h
+++ b/trikControl/src/eventDeviceWorker.h
@@ -36,6 +36,8 @@ public:
 	EventDeviceWorker(const QString &deviceFilePath, DeviceState &state
 			, const trikHal::HardwareAbstractionInterface &hardwareAbstraction);
 
+	void init();
+
 signals:
 	/// Emitted when there is new event in an event file.
 	/// @param event - type of the event.
@@ -51,6 +53,10 @@ private slots:
 private:
 	/// Underlying event file that watches actual event file from operating system.
 	QScopedPointer<trikHal::EventFileInterface> mEventFile;
+
+	DeviceState &mState;
+	const trikHal::HardwareAbstractionInterface &mHardwareAbstraction;
+	const QString mEventFileName;
 };
 
 }

--- a/trikControl/src/eventDeviceWorker.h
+++ b/trikControl/src/eventDeviceWorker.h
@@ -36,6 +36,7 @@ public:
 	EventDeviceWorker(const QString &deviceFilePath, DeviceState &state
 			, const trikHal::HardwareAbstractionInterface &hardwareAbstraction);
 
+	/// Execute init() after worker thread started.
 	void init();
 
 signals:

--- a/trikControl/src/keys.cpp
+++ b/trikControl/src/keys.cpp
@@ -34,8 +34,9 @@ Keys::Keys(const trikKernel::Configurer &configurer, const trikHal::HardwareAbst
 {
 	mKeysWorker.reset(new KeysWorker(configurer.attributeByDevice("keys", "deviceFile"), mState, hardwareAbstraction));
 	if (!mState.isFailed()) {
-		connect(mKeysWorker.data(), SIGNAL(buttonPressed(int, int)), this, SIGNAL(buttonPressed(int, int)));
-		connect(mKeysWorker.data(), SIGNAL(buttonPressed(int, int)), this, SLOT(changeButtonState(int, int)));
+		connect(mKeysWorker.data(), &KeysWorker::buttonPressed, this, &Keys::buttonPressed);
+		connect(mKeysWorker.data(), &KeysWorker::buttonPressed, this, &Keys::changeButtonState);
+		connect(&mWorkerThread, &QThread::started, mKeysWorker.data(), &KeysWorker::init);
 		mKeysWorker->moveToThread(&mWorkerThread);
 
 		QLOG_INFO() << "Starting Keys worker thread" << &mWorkerThread;

--- a/trikControl/src/keys.cpp
+++ b/trikControl/src/keys.cpp
@@ -34,10 +34,11 @@ Keys::Keys(const trikKernel::Configurer &configurer, const trikHal::HardwareAbst
 {
 	mKeysWorker.reset(new KeysWorker(configurer.attributeByDevice("keys", "deviceFile"), mState, hardwareAbstraction));
 	if (!mState.isFailed()) {
+		mKeysWorker->moveToThread(&mWorkerThread);
+
 		connect(mKeysWorker.data(), &KeysWorker::buttonPressed, this, &Keys::buttonPressed);
 		connect(mKeysWorker.data(), &KeysWorker::buttonPressed, this, &Keys::changeButtonState);
 		connect(&mWorkerThread, &QThread::started, mKeysWorker.data(), &KeysWorker::init);
-		mKeysWorker->moveToThread(&mWorkerThread);
 
 		QLOG_INFO() << "Starting Keys worker thread" << &mWorkerThread;
 

--- a/trikControl/src/keysWorker.cpp
+++ b/trikControl/src/keysWorker.cpp
@@ -24,10 +24,16 @@ static const int evKey = 1;
 
 KeysWorker::KeysWorker(const QString &keysPath, DeviceState &state
 		, const trikHal::HardwareAbstractionInterface &hardwareAbstraction)
-	: mEventFile(hardwareAbstraction.createEventFile(keysPath))
+	: mHardwareAbstraction(hardwareAbstraction)
+	, mKeysPath(keysPath)
 	, mState(state)
 {
 	mState.start();
+}
+
+void KeysWorker::init()
+{
+	mEventFile.reset(mHardwareAbstraction.createEventFile(mKeysPath));
 	if (!mEventFile->open()) {
 		mState.fail();
 		return;

--- a/trikControl/src/keysWorker.h
+++ b/trikControl/src/keysWorker.h
@@ -38,6 +38,9 @@ public:
 	KeysWorker(const QString &keysPath, DeviceState &state
 			, const trikHal::HardwareAbstractionInterface &hardwareAbstraction);
 
+	/// Execute init() after worker thread started.
+	void init();
+
 	/// Clear data about previous key pressures.
 	void reset();
 
@@ -60,6 +63,9 @@ private:
 	int mButtonValue = 0;
 	QSet<int> mWasPressed;
 	QReadWriteLock mLock;
+
+	const trikHal::HardwareAbstractionInterface &mHardwareAbstraction;
+	const QString &mKeysPath;
 
 	/// Device state object, shared between worker and proxy.
 	DeviceState &mState;

--- a/trikControl/src/keysWorker.h
+++ b/trikControl/src/keysWorker.h
@@ -65,7 +65,7 @@ private:
 	QReadWriteLock mLock;
 
 	const trikHal::HardwareAbstractionInterface &mHardwareAbstraction;
-	const QString &mKeysPath;
+	const QString mKeysPath;
 
 	/// Device state object, shared between worker and proxy.
 	DeviceState &mState;

--- a/trikControl/src/rangeSensorWorker.cpp
+++ b/trikControl/src/rangeSensorWorker.cpp
@@ -30,6 +30,7 @@ RangeSensorWorker::RangeSensorWorker(const QString &eventFile, DeviceState &stat
 	, mHardwareAbstraction(hardwareAbstraction)
 	, mEventFileName(eventFile)
 {
+	mState.start();
 }
 
 RangeSensorWorker::~RangeSensorWorker()
@@ -65,8 +66,6 @@ void RangeSensorWorker::stop()
 
 void RangeSensorWorker::init()
 {
-	mState.start();
-
 	mEventFile.reset(mHardwareAbstraction.createEventFile(mEventFileName));
 
 	connect(mEventFile.data(), &trikHal::EventFileInterface::newEvent, this, &RangeSensorWorker::onNewEvent);

--- a/trikControl/src/vectorSensorWorker.cpp
+++ b/trikControl/src/vectorSensorWorker.cpp
@@ -30,8 +30,9 @@ using namespace trikControl;
 
 VectorSensorWorker::VectorSensorWorker(const QString &eventFile, DeviceState &state
 		, const trikHal::HardwareAbstractionInterface &hardwareAbstraction)
-	: mEventFile(hardwareAbstraction.createEventFile(eventFile))
-	, mState(state)
+	: mState(state)
+	, mHardwareAbstraction(hardwareAbstraction)
+	, mEventFileName(eventFile)
 	, mLastEventTimer(this)
 	, mTryReopenTimer(this)
 {
@@ -40,6 +41,8 @@ VectorSensorWorker::VectorSensorWorker(const QString &eventFile, DeviceState &st
 
 void VectorSensorWorker::init()
 {
+	mEventFile.reset(mHardwareAbstraction.createEventFile(mEventFileName));
+
 	mReading << 0 << 0 << 0 << 0 << 0 << 0;
 	mReadingUnsynced = mReading;
 

--- a/trikControl/src/vectorSensorWorker.h
+++ b/trikControl/src/vectorSensorWorker.h
@@ -80,6 +80,9 @@ private:
 	/// Device state, shared between worker and proxy.
 	DeviceState &mState;
 
+	const trikHal::HardwareAbstractionInterface &mHardwareAbstraction;
+	const QString &mEventFileName;
+
 	/// Timer that reopens event file when there are no events for too long (1 second hardcoded).
 	QTimer mLastEventTimer;
 

--- a/trikControl/src/vectorSensorWorker.h
+++ b/trikControl/src/vectorSensorWorker.h
@@ -81,7 +81,7 @@ private:
 	DeviceState &mState;
 
 	const trikHal::HardwareAbstractionInterface &mHardwareAbstraction;
-	const QString &mEventFileName;
+	const QString mEventFileName;
 
 	/// Timer that reopens event file when there are no events for too long (1 second hardcoded).
 	QTimer mLastEventTimer;


### PR DESCRIPTION
The EventFile was created before moveToThread, so to avoid this, we
eventFile.reset() in the init section that starts after the new thread
is started.