### PR TITLE
TrikAbstractTimer class in scriptControl

### DIFF
--- a/trikScriptRunner/include/trikScriptRunner/trikAbstractTimer.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikAbstractTimer.h
@@ -27,27 +27,19 @@ class TRIKSCRIPTRUNNER_EXPORT TrikAbstractTimer : public QObject
 
 public:
 	/// Returns true if the timer is working now or false otherwise
-	virtual bool isTicking() const = 0;
-	/// Alias for isTicking for better symmetry with QTimer
-	virtual bool isActive() const { return isTicking(); }
+	virtual bool isActive() const = 0;
 	virtual int interval() const = 0;
 	virtual void setInterval(int ms) = 0;
 
-	/// If \a repeatable then the timer will set itself up again when timeout reached.
-	/// By default timers are not repeatable.
-	/// TODO: Remove such methods, because it is QTimer herit now.
-	virtual void setRepeatable(bool repeatable) = 0;
+	virtual void setSingleShot(bool isSingleShot) = 0;
 
 public slots:
 	virtual void start() = 0;
 	virtual void start(int ms) = 0;
-	Q_INVOKABLE virtual void stop() = 0;
+	virtual void stop() = 0;
 
 signals:
 	void timeout();
-
-protected slots:
-	virtual void onTimeout();
 };
 
 }

--- a/trikScriptRunner/include/trikScriptRunner/trikAbstractTimer.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikAbstractTimer.h
@@ -1,0 +1,53 @@
+/* Copyright 2021 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <QtCore/QObject>
+#include <QTimer>
+
+#include "trikScriptRunnerDeclSpec.h"
+
+namespace trikScriptRunner {
+
+class TRIKSCRIPTRUNNER_EXPORT TrikAbstractTimer : public QObject
+{
+	Q_OBJECT
+
+public:
+	/// Returns true if the timer is working now or false otherwise
+	virtual bool isTicking() const = 0;
+	/// Alias for isTicking for better symmetry with QTimer
+	virtual bool isActive() const { return isTicking(); }
+	virtual int interval() const = 0;
+	virtual void setInterval(int ms) = 0;
+
+	/// If \a repeatable then the timer will set itself up again when timeout reached.
+	/// By default timers are not repeatable.
+	/// TODO: Remove such methods, because it is QTimer herit now.
+	virtual void setRepeatable(bool repeatable) = 0;
+
+public slots:
+	virtual void start() = 0;
+	virtual void start(int ms) = 0;
+	Q_INVOKABLE virtual void stop() = 0;
+
+signals:
+	void timeout();
+
+protected slots:
+	virtual void onTimeout();
+};
+
+}

--- a/trikScriptRunner/include/trikScriptRunner/trikRealTimer.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikRealTimer.h
@@ -27,13 +27,13 @@ class TRIKSCRIPTRUNNER_EXPORT TrikRealTimer : public TrikAbstractTimer
 public:
 	TrikRealTimer();
 
-	bool isTicking() const override;
+	bool isActive() const override;
 	int interval() const override;
 	void start() override;
 	void start(int ms) override;
 	void stop() override;
 	void setInterval(int ms) override;
-	void setRepeatable(bool repeatable) override;
+	void setSingleShot(bool isSingleShot) override;
 
 private:
 	QTimer mTimer;

--- a/trikScriptRunner/include/trikScriptRunner/trikRealTimer.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikRealTimer.h
@@ -1,0 +1,42 @@
+/* Copyright 2021 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <QtCore/QTimer>
+
+#include "trikAbstractTimer.h"
+#include "trikScriptRunnerDeclSpec.h"
+
+namespace trikScriptRunner {
+
+/// Timer implementation for real-life time
+class TRIKSCRIPTRUNNER_EXPORT TrikRealTimer : public TrikAbstractTimer
+{
+public:
+	TrikRealTimer();
+
+	bool isTicking() const override;
+	int interval() const override;
+	void start() override;
+	void start(int ms) override;
+	void stop() override;
+	void setInterval(int ms) override;
+	void setRepeatable(bool repeatable) override;
+
+private:
+	QTimer mTimer;
+};
+
+}

--- a/trikScriptRunner/include/trikScriptRunner/trikScriptControlInterface.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikScriptControlInterface.h
@@ -27,6 +27,9 @@ class TRIKSCRIPTRUNNER_EXPORT TrikScriptControlInterface : public QObject
 	Q_OBJECT
 
 public:
+	/// Registers required metatypes
+	TrikScriptControlInterface();
+
 	/// Returns true if a script is in event-driven running mode, so it shall wait for events when script is executed.
 	/// If it is false, script will exit immediately.
 	virtual bool isInEventDrivenMode() const = 0;

--- a/trikScriptRunner/include/trikScriptRunner/trikScriptControlInterface.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikScriptControlInterface.h
@@ -14,16 +14,10 @@
 
 #pragma once
 
-#include <QtCore/QTimer>
 #include <trikControl/brickInterface.h>
+#include "trikAbstractTimer.h"
 
-#ifndef TRIKSCRIPTRUNNER_EXPORT
-#  if defined(TRIKSCRIPTRUNNER_LIBRARY)
-#    define TRIKSCRIPTRUNNER_EXPORT Q_DECL_EXPORT
-#  else
-#    define TRIKSCRIPTRUNNER_EXPORT Q_DECL_IMPORT
-#  endif
-#endif
+#include "trikScriptRunnerDeclSpec.h"
 
 namespace trikScriptRunner {
 
@@ -41,7 +35,7 @@ public:
 	Q_INVOKABLE virtual QVector<int32_t> getPhoto() = 0;
 
 	/// Starts a new timer with given interval and returns reference to it.
-	Q_INVOKABLE virtual QTimer *timer(int milliseconds) = 0;
+	Q_INVOKABLE virtual TrikAbstractTimer *timer(int milliseconds) = 0;
 
 	/// Waits given amount of time in milliseconds and returns.
 	Q_INVOKABLE virtual void wait(const int &milliseconds) = 0;

--- a/trikScriptRunner/include/trikScriptRunner/trikScriptRunnerDeclSpec.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikScriptRunnerDeclSpec.h
@@ -1,0 +1,25 @@
+/* Copyright 2021 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#pragma once
+
+#include <QtCore/qglobal.h>
+
+#ifndef TRIKSCRIPTRUNNER_EXPORT
+#  if defined(TRIKSCRIPTRUNNER_LIBRARY)
+#    define TRIKSCRIPTRUNNER_EXPORT Q_DECL_EXPORT
+#  else
+#    define TRIKSCRIPTRUNNER_EXPORT Q_DECL_IMPORT
+#  endif
+#endif

--- a/trikScriptRunner/src/scriptExecutionControl.cpp
+++ b/trikScriptRunner/src/scriptExecutionControl.cpp
@@ -29,6 +29,7 @@ using namespace trikScriptRunner;
 
 ScriptExecutionControl::ScriptExecutionControl(trikControl::BrickInterface &brick)
 	: mBrick(brick) {
+	qRegisterMetaType<TrikAbstractTimer *>("TrikAbstractTimer*");
 	qRegisterMetaType<QVector<int32_t>>("QVector<int32_t>");
 }
 
@@ -42,16 +43,16 @@ void ScriptExecutionControl::reset()
 	mInEventDrivenMode = false;
 	emit stopWaiting();
 	for (auto &&timer : mTimers) {
-		QMetaObject::invokeMethod(timer, &QTimer::stop, Qt::QueuedConnection);
+		QMetaObject::invokeMethod(timer, &TrikRealTimer::stop, Qt::QueuedConnection);
 		timer->deleteLater();
 	}
 
 	mTimers.clear();
 }
 
-QTimer* ScriptExecutionControl::timer(int milliseconds)
+TrikAbstractTimer* ScriptExecutionControl::timer(int milliseconds)
 {
-	QTimer *result = new QTimer();
+	TrikRealTimer *result = new TrikRealTimer();
 	mTimers.append(result);
 	result->start(milliseconds);
 	return result;

--- a/trikScriptRunner/src/scriptExecutionControl.cpp
+++ b/trikScriptRunner/src/scriptExecutionControl.cpp
@@ -29,8 +29,6 @@ using namespace trikScriptRunner;
 
 ScriptExecutionControl::ScriptExecutionControl(trikControl::BrickInterface &brick)
 	: mBrick(brick) {
-	qRegisterMetaType<TrikAbstractTimer *>("TrikAbstractTimer*");
-	qRegisterMetaType<QVector<int32_t>>("QVector<int32_t>");
 }
 
 ScriptExecutionControl::~ScriptExecutionControl()
@@ -52,7 +50,7 @@ void ScriptExecutionControl::reset()
 
 TrikAbstractTimer* ScriptExecutionControl::timer(int milliseconds)
 {
-	TrikRealTimer *result = new TrikRealTimer();
+	auto result = new TrikRealTimer();
 	mTimers.append(result);
 	result->start(milliseconds);
 	return result;

--- a/trikScriptRunner/src/scriptExecutionControl.h
+++ b/trikScriptRunner/src/scriptExecutionControl.h
@@ -15,10 +15,10 @@
 #pragma once
 
 #include <QtCore/QList>
-#include <QtCore/QTimer>
 #include <QtCore/QStringList>
 #include <trikControl/brickInterface.h>
 #include <trikScriptControlInterface.h>
+#include <trikRealTimer.h>
 
 namespace trikScriptRunner {
 
@@ -42,7 +42,7 @@ public:
 	Q_INVOKABLE QVector<int32_t> getPhoto() override;
 
 	/// Starts a new timer with given interval and returns reference to it.
-	Q_INVOKABLE QTimer *timer(int milliseconds) override;
+	Q_INVOKABLE TrikAbstractTimer *timer(int milliseconds) override;
 
 	/// Waits given amount of time in milliseconds and returns.
 	Q_INVOKABLE void wait(const int &milliseconds) override;
@@ -89,7 +89,7 @@ signals:
 	void textInStdOut(const QString &text);
 
 private:
-	QList<QTimer *> mTimers; // Has ownership.
+	QList<TrikRealTimer *> mTimers; // Has ownership.
 	trikControl::BrickInterface &mBrick;
 
 

--- a/trikScriptRunner/src/trikAbstractTimer.cpp
+++ b/trikScriptRunner/src/trikAbstractTimer.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2021 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "trikAbstractTimer.h"
+
+void trikScriptRunner::TrikAbstractTimer::onTimeout()
+{
+	emit timeout();
+}

--- a/trikScriptRunner/src/trikRealTimer.cpp
+++ b/trikScriptRunner/src/trikRealTimer.cpp
@@ -18,11 +18,10 @@ using namespace trikScriptRunner;
 
 TrikRealTimer::TrikRealTimer()
 {
-	setRepeatable(true);
 	QObject::connect(&mTimer, &QTimer::timeout, this, &TrikRealTimer::timeout);
 }
 
-bool TrikRealTimer::isTicking() const
+bool TrikRealTimer::isActive() const
 {
 	return mTimer.isActive();
 }
@@ -53,7 +52,7 @@ void TrikRealTimer::setInterval(int ms)
 	mTimer.setInterval(ms);
 }
 
-void TrikRealTimer::setRepeatable(bool repeatable)
+void TrikRealTimer::setSingleShot(bool isSingleShot)
 {
-	mTimer.setSingleShot(!repeatable);
+	mTimer.setSingleShot(isSingleShot);
 }

--- a/trikScriptRunner/src/trikRealTimer.cpp
+++ b/trikScriptRunner/src/trikRealTimer.cpp
@@ -1,0 +1,59 @@
+/* Copyright 2021 CyberTech Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+#include "trikRealTimer.h"
+
+using namespace trikScriptRunner;
+
+TrikRealTimer::TrikRealTimer()
+{
+	setRepeatable(true);
+	QObject::connect(&mTimer, &QTimer::timeout, this, &TrikRealTimer::timeout);
+}
+
+bool TrikRealTimer::isTicking() const
+{
+	return mTimer.isActive();
+}
+
+int TrikRealTimer::interval() const
+{
+	return mTimer.interval();
+}
+
+void TrikRealTimer::start()
+{
+	start(mTimer.interval());
+}
+
+void TrikRealTimer::start(int ms)
+{
+	mTimer.setInterval(ms);
+	mTimer.start();
+}
+
+void TrikRealTimer::stop()
+{
+	mTimer.stop();
+}
+
+void TrikRealTimer::setInterval(int ms)
+{
+	mTimer.setInterval(ms);
+}
+
+void TrikRealTimer::setRepeatable(bool repeatable)
+{
+	mTimer.setSingleShot(!repeatable);
+}

--- a/trikScriptRunner/src/trikScriptControlInterface.cpp
+++ b/trikScriptRunner/src/trikScriptControlInterface.cpp
@@ -12,9 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License. */
 
-#include "trikAbstractTimer.h"
+#include "trikScriptControlInterface.h"
 
-void trikScriptRunner::TrikAbstractTimer::onTimeout()
+trikScriptRunner::TrikScriptControlInterface::TrikScriptControlInterface()
 {
-	emit timeout();
+	qRegisterMetaType<TrikAbstractTimer *>("TrikAbstractTimer*");
+	qRegisterMetaType<QVector<int32_t>>("QVector<int32_t>");
 }

--- a/trikScriptRunner/trikScriptRunner.pro
+++ b/trikScriptRunner/trikScriptRunner.pro
@@ -22,6 +22,8 @@ include(./PyTrikControl/PyTrikControl.pri)
 PUBLIC_HEADERS += \
 	$$PWD/include/trikScriptRunner/trikScriptRunner.h \
 	$$PWD/include/trikScriptRunner/trikScriptControlInterface.h \
+	$$PWD/include/trikScriptRunner/trikAbstractTimer.h \
+	$$PWD/include/trikScriptRunner/trikRealTimer.h \
 
 HEADERS += \
 	$$PWD/src/scriptable.h \
@@ -35,6 +37,7 @@ HEADERS += \
 	$$PWD/include/trikScriptRunner/trikPythonRunner.h \
 	$$PWD/include/trikScriptRunner/trikJavaScriptRunner.h \
 	$$PWD/include/trikScriptRunner/trikVariablesServer.h \
+	$$PWD/include/trikScriptRunner/trikScriptRunnerDeclSpec.h
 
 SOURCES += \
 	$$PWD/src/scriptExecutionControl.cpp \
@@ -46,7 +49,9 @@ SOURCES += \
 	$$PWD/src/threading.cpp \
 	$$PWD/src/utils.cpp \
 	$$PWD/src/scriptThread.cpp \
-	$$PWD/src/trikVariablesServer.cpp
+	$$PWD/src/trikVariablesServer.cpp \
+	$$PWD/src/trikAbstractTimer.cpp \
+	$$PWD/src/trikRealTimer.cpp
 
 OTHER_FILES += \
 	$$PWD/system.js \

--- a/trikScriptRunner/trikScriptRunner.pro
+++ b/trikScriptRunner/trikScriptRunner.pro
@@ -50,8 +50,8 @@ SOURCES += \
 	$$PWD/src/utils.cpp \
 	$$PWD/src/scriptThread.cpp \
 	$$PWD/src/trikVariablesServer.cpp \
-	$$PWD/src/trikAbstractTimer.cpp \
-	$$PWD/src/trikRealTimer.cpp
+	$$PWD/src/trikRealTimer.cpp \
+	$$PWD/src/trikScriptControlInterface.cpp
 
 OTHER_FILES += \
 	$$PWD/system.js \


### PR DESCRIPTION
Moved the `AbstractTimer` and its heir `RealTimer` from the studio to the runtime. 