### PR TITLE
Move timeInterval to common scriptExecutionControl

### DIFF
--- a/translations/fr/trikScriptRunner_fr.ts
+++ b/translations/fr/trikScriptRunner_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trikScriptRunner::ScriptEngineWorker</name>
     <message>
-        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+284"/>
+        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+278"/>
         <source>Line %1: %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/fr/trikScriptRunner_fr.ts
+++ b/translations/fr/trikScriptRunner_fr.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trikScriptRunner::ScriptEngineWorker</name>
     <message>
-        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+278"/>
+        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+277"/>
         <source>Line %1: %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/ru/trikScriptRunner_ru.ts
+++ b/translations/ru/trikScriptRunner_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trikScriptRunner::ScriptEngineWorker</name>
     <message>
-        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+278"/>
+        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+277"/>
         <source>Line %1: %2</source>
         <translation type="unfinished">Строка %1: %2</translation>
     </message>

--- a/translations/ru/trikScriptRunner_ru.ts
+++ b/translations/ru/trikScriptRunner_ru.ts
@@ -4,7 +4,7 @@
 <context>
     <name>trikScriptRunner::ScriptEngineWorker</name>
     <message>
-        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+284"/>
+        <location filename="../../trikScriptRunner/src/scriptEngineWorker.cpp" line="+278"/>
         <source>Line %1: %2</source>
         <translation type="unfinished">Строка %1: %2</translation>
     </message>

--- a/trikScriptRunner/include/trikScriptRunner/trikScriptControlInterface.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikScriptControlInterface.h
@@ -64,6 +64,9 @@ public:
 	/// Removes a file.
 	Q_INVOKABLE virtual void removeFile(const QString &file) = 0;
 
+	/// Counts time interval between two packed data of time using TimeVal
+	Q_INVOKABLE virtual int timeInterval(int packedTimeLeft, int packedTimeRight) = 0;
+
 public slots:
 	/// Starts event loop for script.
 	virtual void run() = 0;

--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -209,7 +209,7 @@ bool PythonEngineWorker::importTrikPy()
 	}
 
 	addSearchModuleDirectory(trikKernel::Paths::systemScriptsPath());
-	mMainContext.evalScript("import TRIK;from TRIK import *");
+	mMainContext.evalScript("from TRIK import *");
 
 	return true;
 }

--- a/trikScriptRunner/src/scriptEngineWorker.cpp
+++ b/trikScriptRunner/src/scriptEngineWorker.cpp
@@ -114,7 +114,6 @@ ScriptEngineWorker::ScriptEngineWorker(trikControl::BrickInterface *brick
 	connect(&mThreading, &Threading::variablesReady, this, &ScriptEngineWorker::variablesReady);
 
 	registerUserFunction("print", print);
-	registerUserFunction("timeInterval", timeInterval);
 	registerUserFunction("include", include);
 }
 

--- a/trikScriptRunner/src/scriptEngineWorker.cpp
+++ b/trikScriptRunner/src/scriptEngineWorker.cpp
@@ -98,12 +98,6 @@ QScriptValue print(QScriptContext *context, QScriptEngine *engine)
 	return engine->toScriptValue(result);
 }
 
-QScriptValue timeInterval(QScriptContext *context, QScriptEngine *engine)
-{
-	int result = trikKernel::TimeVal::timeInterval(context->argument(0).toInt32(), context->argument(1).toInt32());
-	return engine->toScriptValue(result);
-}
-
 ScriptEngineWorker::ScriptEngineWorker(trikControl::BrickInterface *brick
 		, trikNetwork::MailboxInterface * mailbox
 		, TrikScriptControlInterface *scriptControl

--- a/trikScriptRunner/src/scriptExecutionControl.cpp
+++ b/trikScriptRunner/src/scriptExecutionControl.cpp
@@ -146,6 +146,11 @@ void ScriptExecutionControl::removeFile(const QString &file)
 	out.remove();
 }
 
+int ScriptExecutionControl::timeInterval(int packedTimeLeft, int packedTimeRight)
+{
+	return trikKernel::TimeVal::timeInterval(packedTimeLeft, packedTimeRight);
+}
+
 QVector<int32_t> ScriptExecutionControl::getPhoto()
 {
 	return trikControl::Utilities::rescalePhoto(mBrick->getStillImage());

--- a/trikScriptRunner/src/scriptExecutionControl.h
+++ b/trikScriptRunner/src/scriptExecutionControl.h
@@ -69,6 +69,9 @@ public:
 	/// Removes a file.
 	Q_INVOKABLE void removeFile(const QString &file) override;
 
+	/// Counts time interval between two packed data of time using TimeVal
+	Q_INVOKABLE int timeInterval(int packedTimeLeft, int packedTimeRight) override;
+
 public slots:
 	/// Starts event loop for script.
 	void run() override;


### PR DESCRIPTION
No global `timeIterval` function for js now. Only `script.timeInterval`.
Fixes #663