### PR TITLE
Fix crash after stop.

### DIFF
--- a/trikScriptRunner/include/trikScriptRunner/trikJavaScriptRunner.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikJavaScriptRunner.h
@@ -18,6 +18,8 @@
 #include "trikScriptRunnerInterface.h"
 #include "trikVariablesServer.h"
 
+#include <QPointer>
+
 namespace trikNetwork {
 class MailboxInterface;
 }
@@ -65,7 +67,7 @@ private:
 	QSharedPointer<TrikScriptControlInterface> mScriptController;
 
 	/// Has ownership, memory is managed by thread and deleteLater().
-	ScriptEngineWorker *mScriptEngineWorker;
+	QPointer<ScriptEngineWorker> mScriptEngineWorker;
 	QThread mWorkerThread;
 
 	int mMaxScriptId;

--- a/trikScriptRunner/include/trikScriptRunner/trikPythonRunner.h
+++ b/trikScriptRunner/include/trikScriptRunner/trikPythonRunner.h
@@ -17,6 +17,8 @@
 #include "trikScriptRunnerInterface.h"
 #include "trikScriptControlInterface.h"
 
+#include <QPointer>
+
 namespace trikNetwork {
 class MailboxInterface;
 }
@@ -60,7 +62,7 @@ public slots:
 private:
 
 	/// Has ownership, memory is managed by thread and deleteLater().
-	PythonEngineWorker *mScriptEngineWorker { nullptr };
+	QPointer<PythonEngineWorker> mScriptEngineWorker;
 	QThread mWorkerThread;
 };
 

--- a/trikScriptRunner/src/trikJavaScriptRunner.cpp
+++ b/trikScriptRunner/src/trikJavaScriptRunner.cpp
@@ -107,8 +107,10 @@ void TrikJavaScriptRunner::runDirectCommand(const QString &command)
 
 void TrikJavaScriptRunner::abort()
 {
-	mScriptEngineWorker->stopScript();
-	mScriptEngineWorker->resetBrick();
+	if (mScriptEngineWorker) {
+		mScriptEngineWorker->stopScript();
+		mScriptEngineWorker->resetBrick();
+	}
 }
 
 void TrikJavaScriptRunner::onScriptStart(int scriptId)

--- a/trikScriptRunner/src/trikPythonRunner.cpp
+++ b/trikScriptRunner/src/trikPythonRunner.cpp
@@ -93,8 +93,10 @@ void TrikPythonRunner::runDirectCommand(const QString &command)
 
 void TrikPythonRunner::abort()
 {
-	mScriptEngineWorker->stopScript();
-	mScriptEngineWorker->resetBrick();
+	if (mScriptEngineWorker) {
+		mScriptEngineWorker->stopScript();
+		mScriptEngineWorker->resetBrick();
+	}
 }
 
 QStringList TrikPythonRunner::knownMethodNames() const


### PR DESCRIPTION
`abort()` can be called from another thread when the field `mScriptEngineWorker` have been deleted by `deleteLater`
this is (probably?) a design issue, but QPointer helps