### PR TITLE
Fix connection between several robots

### DIFF
--- a/trikNetwork/src/connection.cpp
+++ b/trikNetwork/src/connection.cpp
@@ -57,7 +57,7 @@ void Connection::init(const QHostAddress &ip, int port)
 
 	mSocket->connectToHost(ip, port);
 
-	if (!mSocket->waitForConnected()) {
+	if (!mSocket->waitForConnected(1000)) {
 		QLOG_ERROR() << "Connection to" << ip << ":" << port << "failed with " << mSocket->error();
 		doDisconnect();
 		return;

--- a/trikNetwork/src/mailbox.cpp
+++ b/trikNetwork/src/mailbox.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2014 - 2015 CyberTech Labs Ltd.
+/* Copyright 2014 - 2021 CyberTech Labs Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/trikNetwork/src/mailbox.h
+++ b/trikNetwork/src/mailbox.h
@@ -58,7 +58,7 @@ public:
 
 	Q_INVOKABLE int myHullNumber() const override;
 
-	/// True iff the server is running
+	/// True iff the server is running.
 	Q_INVOKABLE bool hasServer() const;
 
 public slots:

--- a/trikNetwork/src/mailboxServer.cpp
+++ b/trikNetwork/src/mailboxServer.cpp
@@ -211,7 +211,6 @@ void MailboxServer::onNewConnection(const QHostAddress &ip, int clientPort, int 
 	// Send known connection information to newly connected robot.
 	const auto c = qobject_cast<MailboxConnection *>(connection(ip, clientPort));
 	if (c != nullptr) {
-		mKnownRobotsLock.lockForRead();
 		for (const auto &endpoint : endpoints) {
 			mKnownRobotsLock.lockForRead();
 			int endpointHullNumber = mKnownRobots.key(endpoint);

--- a/trikNetwork/src/mailboxServer.h
+++ b/trikNetwork/src/mailboxServer.h
@@ -20,6 +20,7 @@
 #include <QtCore/QQueue>
 #include <QtNetwork/QHostAddress>
 
+#include "mailboxConnection.h"
 #include "trikServer.h"
 
 namespace trikNetwork {
@@ -80,7 +81,7 @@ public:
 	/// Returns one incoming message or empty string if there are none.
 	Q_INVOKABLE QString receive();
 
-	/// Returns true iff the server was started and is listening
+	/// Returns true iff the server was started and is listening.
 	bool hasServer() const;
 
 signals:
@@ -93,26 +94,28 @@ private slots:
 	void onNewData(const QHostAddress &ip, int port, const QByteArray &data);
 
 private:
-	Connection *connectTo(const QHostAddress &ip, int port);
+	MailboxConnection *connectTo(const QHostAddress &ip, int port);
 
-	Connection *connectionFactory();
+	MailboxConnection *connectionFactory();
 
-	void connectConnection(Connection * connection);
+	void connectConnection(MailboxConnection * connection);
 
 	static QHostAddress determineMyIp();
 
 	struct Endpoint {
 		QHostAddress ip;
+		/// The port that the endpoint robot specified as available for connection.
 		int serverPort;
+		/// The port we are connected to.
 		int connectedPort;
 	};
 
-	Connection *prepareConnection(Endpoint &endpoint);
+	MailboxConnection *prepareConnection(Endpoint &endpoint);
 
 	void loadSettings();
 	void saveSettings();
 
-	void forEveryConnection(const std::function<void(Connection *)> &method, int hullNumber = -1);
+	void forEveryConnection(const std::function<void(MailboxConnection *)> &method, int hullNumber = -1);
 
 	int mHullNumber;
 	QHostAddress mMyIp;

--- a/trikNetwork/src/trikServer.cpp
+++ b/trikNetwork/src/trikServer.cpp
@@ -72,6 +72,7 @@ int TrikServer::activeConnections() const
 void TrikServer::incomingConnection(qintptr socketDescriptor)
 {
 	QLOG_INFO() << "New connection, socket descriptor: " << socketDescriptor;
+
 	Connection * const connectionWorker = mConnectionFactory();
 	startConnection(connectionWorker);
 

--- a/trikNetwork/src/trikServer.cpp
+++ b/trikNetwork/src/trikServer.cpp
@@ -72,7 +72,6 @@ int TrikServer::activeConnections() const
 void TrikServer::incomingConnection(qintptr socketDescriptor)
 {
 	QLOG_INFO() << "New connection, socket descriptor: " << socketDescriptor;
-
 	Connection * const connectionWorker = mConnectionFactory();
 	startConnection(connectionWorker);
 


### PR DESCRIPTION
Because of the subscription in the method `connectTo` at the start of each new socket - each connection was reconnected again.
There was also a problem because we didn't save the new clientPort when we called `prepareConnection`