### PR TITLE
Add CI with TRIK toolchain

### DIFF
--- a/.github/workflows/trik-toolchain.yml
+++ b/.github/workflows/trik-toolchain.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Use ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ github.workflow }}
+          key: ${{ github.ref_name }}-${{ github.job }}
 
       - name: Check available tools
         run: |

--- a/.github/workflows/trik-toolchain.yml
+++ b/.github/workflows/trik-toolchain.yml
@@ -1,0 +1,152 @@
+name: 'TRIK toolchain on Ubuntu Latest'
+on:
+  push:
+    branches:
+  pull_request:
+    branches:
+  workflow_dispatch:
+
+jobs:
+  trik-toolchain:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0} # to force import of ~/.bash_profile
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Restore TRIK toolchain
+        uses: actions/cache/restore@v3
+        with:
+          path: /opt/trik-sdk
+          key: trik-sdk
+
+      - name: Check if TRIK toolchain is up-to-date
+        id: trik-toolchain-check
+        run: |
+            curl -O https://dl.trikset.com/distro/latest-full/trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh.sha256
+            diff -qN trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh.sha256 \
+                     /opt/trik-sdk/trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh.sha256 \
+                     && echo "install=false" >> $GITHUB_OUTPUT \
+                     || echo "install=true" >> $GITHUB_OUTPUT
+
+      - name: Install TRIK toolchain
+        if: steps.trik-toolchain-check.outputs.install == true
+        run: |
+            rm -rf /opt/trik-sdk
+            curl -O https://dl.trikset.com/distro/latest-full/trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh
+            chmod +x ./trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh
+            ./trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh -y
+            mv trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh.sha256 /opt/trik-sdk
+
+      - name: Save TRIK toolchain
+        if: steps.trik-toolchain-check.outputs.install == true
+        uses: actions/cache/save@v3
+        with:
+          path: /opt/trik-sdk
+          key: trik-sdk
+
+      - name: Install QEMU with binfmt
+        run: |
+            sudo apt-get install qemu-user-binfmt
+
+      - name: Configure git
+        run: |
+            git --version
+            git config --global core.symlinks true
+            git config --global core.autocrlf false
+
+            #prepare for actions/checkout, otherwise it fails
+            echo "LC_ALL=en_US.utf8" >> $GITHUB_ENV
+            echo "$(dirname $(realpath $(which git)))" >> $GITHUB_PATH
+            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+            echo "PERL5LIB=$PERL5LIB" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Use ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.workflow }}
+
+      - name: Check available tools
+        run: |
+             set -xeo pipefail
+             . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+             uname -a
+             rsync --version
+             qmake --version && qmake -query
+             python3 --version
+             echo $CXX
+             $CXX --version
+             ccache --version
+             qemu-arm --version
+
+      - name: "[TRIK brick] QMake"
+        timeout-minutes: 1
+        run: |
+            . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+            mkdir build-brick
+            cd build-brick
+            qmake CONFIG+=release CONFIG+=noPch CONFIG+=ccache \
+                  "$GITHUB_WORKSPACE/"
+
+      - name: "[TRIK brick] QMake all"
+        timeout-minutes: 3
+        run: |
+            . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+            cd build-brick
+            make -j $(nproc) qmake_all
+
+      - name: "[TRIK brick] Make all"
+        timeout-minutes: 10
+        run: |
+            . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+            cd build-brick
+            make -j $(nproc) all
+
+      - name: "[QEMU + NoPython] QMake"
+        timeout-minutes: 1
+        run: |
+            . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+            mkdir build-qemu
+            cd build-qemu
+            qmake CONFIG+=release CONFIG+=tests CONFIG+=noPch CONFIG+=ccache \
+                  CONFIG+=trik_not_brick CONFIG+=trik_nopython \
+                  "$GITHUB_WORKSPACE/"
+
+      - name: "[QEMU + NoPython] QMake all"
+        timeout-minutes: 3
+        run: |
+            . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+            cd build-qemu
+            make -j $(nproc) qmake_all
+
+      - name: "[QEMU + NoPython] Make all"
+        timeout-minutes: 10
+        run: |
+            . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+            cd build-qemu
+            make -j $(nproc) all
+
+      - name: "[QEMU + NoPython] Unit tests"
+        timeout-minutes: 5
+        run: |
+            . /opt/trik-sdk/environment-setup-arm926ejse-oe-linux-gnueabi
+            cd build-qemu
+            # export TRIK_PYTHONPATH=$(python3 -c "import sys; import os; print(os.pathsep.join(sys.path))")
+            # export PYTHONVERBOSE=2
+            # export PYTHONDEBUG=2
+            # export PYTHONMALLOC=malloc_debug
+            # export PYTHONFAULTHANDLER=1
+            # export PYTHONDEVMODE=1 #only from 3.7, overrides PYTHONMALLOC and some other
+            export QEMU_LD_PREFIX=/opt/trik-sdk/sysroots/arm926ejse-oe-linux-gnueabi/
+            env | sort
+            make -k check TESTARGS="-platform offscreen"

--- a/scripts/azure/install_Linux.sh
+++ b/scripts/azure/install_Linux.sh
@@ -3,6 +3,6 @@ set -euxo pipefail
 
 docker pull trikset/linux-builder
 docker run -d --privileged -v $BUILD_SOURCESDIRECTORY:$BUILD_SOURCESDIRECTORY:rw -w `pwd` --name builder trikset/linux-builder Xvfb :0
-docker exec builder bash -c 'export PATH=/usr/bin:/bin:/usr/sbin:/sbin ; python -V ; python3 -V ; rm -f ~/.bashrc'
+docker exec builder bash -c 'export PATH=/usr/bin:/bin:/usr/sbin:/sbin ; python -V ; python3 -V ; rm -f ~/.bashrc ; git config --global --add safe.directory "*"'
 
 mkdir -p "$BUILDDIR"

--- a/trikHal/trikHal.pro
+++ b/trikHal/trikHal.pro
@@ -82,7 +82,7 @@ SOURCES += \
 	$$PWD/src/stub/stubFifo.cpp \
 	$$PWD/src/stub/stubIIOFile.cpp \
 
-equals(ARCHITECTURE, arm) {
+equals(ARCHITECTURE, arm):!trik_not_brick {
 	SOURCES += $$PWD/src/trik/hardwareAbstractionFactory.cpp
 } else {
 	SOURCES += $$PWD/src/stub/hardwareAbstractionFactory.cpp

--- a/trikKernel/trikKernel.pro
+++ b/trikKernel/trikKernel.pro
@@ -57,7 +57,7 @@ SOURCES += \
 OTHER_FILES += \
 	$$PWD/stubTrikRc \
 
-equals(ARCHITECTURE, arm) {
+equals(ARCHITECTURE, arm):!trik_not_brick {
 	SOURCES += $$PWD/src/trik/paths.cpp
 } else {
 	SOURCES += $$PWD/src/stub/paths.cpp

--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -115,6 +115,7 @@ void PythonEngineWorker::init()
 		} else {
 			QLOG_INFO() << varName << ":" << path;
 		}
+#if PY_MINOR_VERSION >= 8
 		PyPreConfig pyPreconfig;
 		PyPreConfig_InitPythonConfig(&pyPreconfig);
 
@@ -126,8 +127,9 @@ void PythonEngineWorker::init()
 			throw trikKernel::InternalErrorException(e);
 		}
 
-		/// TODO: Must point to local .zip file
 		/// NB! Py_DecodeLocale requires a pre-initialized Python engine
+#endif
+		/// TODO: Must point to local .zip file
 		mPythonPath = Py_DecodeLocale(path.toStdString().data(), nullptr);
 		Py_SetPath(mPythonPath);
 


### PR DESCRIPTION
At some point after the TRIK 20220613 firmware release, the build using the TRIK toolchain broke. 
Fix required:
* wrapping some code for newer Python version with preprocessor directives;
* downgrading Google Test to v1.10.0. Despite v1.12.1 being the last version to support C++11, GCC 4.9 in the TRIK toolchain has incomplete support of C++11. 

To prevent this issue the addition of CI workflow with the TRIK toolchain is required. This PR adds workflow with two build configurations:
* `[TRIK brick]` compiles runtime as if it was compiled for TRIK controller;
* `[QEMU + NoPython]` compiles runtime for ARM without TRIK-specific hardware info and then runs test suite using QEMU. Currently, the Python engine is broken for some reason and thus must be disabled to pass the tests.