### PR TITLE
Fix comparison with string in TRIK toolchain CI

### DIFF
--- a/.github/workflows/trik-toolchain.yml
+++ b/.github/workflows/trik-toolchain.yml
@@ -34,7 +34,7 @@ jobs:
                      || echo "install=true" >> $GITHUB_OUTPUT
 
       - name: Install TRIK toolchain
-        if: steps.trik-toolchain-check.outputs.install == true
+        if: steps.trik-toolchain-check.outputs.install == 'true'
         run: |
             rm -rf /opt/trik-sdk
             curl -O https://dl.trikset.com/distro/latest-full/trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh
@@ -43,7 +43,7 @@ jobs:
             mv trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh.sha256 /opt/trik-sdk
 
       - name: Save TRIK toolchain
-        if: steps.trik-toolchain-check.outputs.install == true
+        if: steps.trik-toolchain-check.outputs.install == 'true'
         uses: actions/cache/save@v3
         with:
           path: /opt/trik-sdk


### PR DESCRIPTION
[#725](https://github.com/trikset/trikRuntime/pull/725) incorrectly compares string with boolean value, causing CI to always fail with non-existing cache