### PR TITLE
Add support for joinNetwork block

### DIFF
--- a/trikNetwork/include/trikNetwork/mailboxInterface.h
+++ b/trikNetwork/include/trikNetwork/mailboxInterface.h
@@ -54,6 +54,9 @@ public:
 	/// Returns true if mailbox is enabled in current configuration.
 	virtual bool isEnabled() = 0;
 
+	/// Sets hull number of this robot and connects to robot by IP and port.
+	virtual void joinNetwork(const QString &ip, int port, int hullNumber) = 0;
+
 public slots:
 	/// Connects to robot by IP and port.
 	virtual void connect(const QString &ip, int port) = 0;

--- a/trikNetwork/src/mailbox.cpp
+++ b/trikNetwork/src/mailbox.cpp
@@ -46,6 +46,11 @@ Mailbox::~Mailbox()
 	}
 }
 
+void Mailbox::joinNetwork(const QString &ip, int port, int hullNumber)
+{
+	QMetaObject::invokeMethod(mWorker.data(), [=](){mWorker->joinNetwork(ip, port, hullNumber);});
+}
+
 bool Mailbox::isConnected() const
 {
 	bool res;

--- a/trikNetwork/src/mailbox.h
+++ b/trikNetwork/src/mailbox.h
@@ -61,6 +61,8 @@ public:
 	/// True iff the server is running.
 	Q_INVOKABLE bool hasServer() const;
 
+	Q_INVOKABLE void joinNetwork(const QString &ip, int port = -1, int hullNumber = -1) override;
+
 public slots:
 	void connect(const QString &ip, int port) override;
 

--- a/trikNetwork/src/mailboxServer.cpp
+++ b/trikNetwork/src/mailboxServer.cpp
@@ -36,6 +36,21 @@ MailboxServer::MailboxServer(quint16 port)
 	loadSettings();
 }
 
+void MailboxServer::joinNetwork(const QString &ip, int port, int hullNumber)
+{
+	if (hullNumber != - 1) {
+		setHullNumber(hullNumber);
+	}
+	if (ip == "") {
+		return;
+	}
+	if (port == -1) {
+		connectTo(ip, mMyPort);
+		return;
+	}
+	connectTo(ip, port);
+}
+
 bool MailboxServer::isConnected()
 {
 	return activeConnections() > 0;

--- a/trikNetwork/src/mailboxServer.h
+++ b/trikNetwork/src/mailboxServer.h
@@ -84,6 +84,9 @@ public:
 	/// Returns true iff the server was started and is listening.
 	bool hasServer() const;
 
+	Q_INVOKABLE void joinNetwork(const QString &ip = "", int port = -1, int hullNumber = -1);
+
+
 signals:
 	/// Emitted when new message was received from a robot with given hull number.
 	void newMessage(int senderHullNumber, const QString &message);

--- a/trikNetwork/src/mailboxServer.h
+++ b/trikNetwork/src/mailboxServer.h
@@ -84,6 +84,7 @@ public:
 	/// Returns true iff the server was started and is listening.
 	bool hasServer() const;
 
+	/// Sets hull number of this robot and connects to robot by IP and port.
 	Q_INVOKABLE void joinNetwork(const QString &ip = "", int port = -1, int hullNumber = -1);
 
 


### PR DESCRIPTION
A minimal `PR` (without cute config files, refactoring, and so on) for implementing the `joinNetwork` block (sets the board number and connects to the robot via IP and port).