### PR TITLE
Remove reset the range sensor state, change the path to the keys device file

### DIFF
--- a/tests/kernel-4.14/test-system-config.xml
+++ b/tests/kernel-4.14/test-system-config.xml
@@ -82,7 +82,7 @@ equal to its class name.
 		<led green="/sys/class/leds/led_green/brightness" red="/sys/class/leds/led_red/brightness" />
 
 		<!--Device file for keys on a brick -->
-		<keys deviceFile="/dev/input/by-path/platform-gpio-keys-event" />
+		<keys deviceFile="/dev/input/by-path/platform-soc@1c00000:gpio-keys-event" />
 
 		<!-- Settings for mailbox server (which enables communication between robots) -->
 		<mailbox port="8889" optional="true" />

--- a/trikControl/configs/kernel-4.14/system-config.xml
+++ b/trikControl/configs/kernel-4.14/system-config.xml
@@ -81,7 +81,7 @@ equal to its class name.
 		<led green="/sys/class/leds/led_green/brightness" red="/sys/class/leds/led_red/brightness" />
 
 		<!--Device file for keys on a brick -->
-		<keys deviceFile="/dev/input/by-path/platform-gpio-keys-event" />
+                <keys deviceFile="/dev/input/by-path/platform-soc@1c00000:gpio-keys-event" />
 
 		<!-- Settings for mailbox server (which enables communication between robots) -->
 		<mailbox port="8889" optional="true" />

--- a/trikControl/src/rangeSensor.cpp
+++ b/trikControl/src/rangeSensor.cpp
@@ -76,11 +76,9 @@ RangeSensor::Status RangeSensor::status() const
 
 void RangeSensor::init()
 {
-	if (mState.isFailed()) {
-		mState.resetFailure();
+	if (!mState.isFailed()) {
+	    QMetaObject::invokeMethod(mSensorWorker.data(), &RangeSensorWorker::init);
 	}
-
-	QMetaObject::invokeMethod(mSensorWorker.data(), &RangeSensorWorker::init);
 }
 
 int RangeSensor::read()


### PR DESCRIPTION
1) Change the path to the keys device file for linux kernel 4.14

2) Do not need to reset the sensor state if it has become a fail (it has become a fault for a reason). One example of a real error: due to the incorrect path to the device file, the sensor state became fail, after that, during initialization, this state was reset and when trying to read data from this sensor, the program terminated with SEGFAULT.