### PR TITLE
Remove the window state setting for DisplayWidget

### DIFF
--- a/trikControl/src/guiWorker.cpp
+++ b/trikControl/src/guiWorker.cpp
@@ -41,7 +41,6 @@ void GuiWorker::init()
 {
 	qRegisterMetaType<QVector<int32_t>>("QVector<int32_t>");
 	mImageWidget.reset(new GraphicsWidget());
-	mImageWidget->setWindowState(Qt::WindowFullScreen);
 	mImageWidget->setWindowFlags(mImageWidget->windowFlags() | Qt::WindowStaysOnTopHint);
 	resetBackground();
 }


### PR DESCRIPTION
For a DisplayWidget that is called from user scripts, you do not need to set the window size, since its size depends on the parent widget and the layout in which we put it. Moreover, for Qt 5.15, because of this line, the widget DisplayWidget is not displayed at all, since it has already been installed in layout.