### PR TITLE
Remove processEvents in PythonEngineWorker::doRun()

### DIFF
--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -388,10 +388,8 @@ void PythonEngineWorker::doRun(const QString &script, const QFileInfo &scriptFil
 
 	auto wasError = mState != ready && PythonQt::self()->hadError();
 	mState = ready;
-	QCoreApplication::processEvents(); //dispatch events before reset
 	mScriptExecutionControl->reset();
 	releaseContext();
-	QCoreApplication::processEvents(); //dispatch events before emitting the signal
 	if (wasError) {
 		emit completed(mErrorMessage, 0);
 	} else {


### PR DESCRIPTION
When the destructor of `trikPythonRunner` is called, `mWorkerThread->quit()` is invoked. The `finished` signal of `mWorkerThread` is connected to `pythonEngineWorker::deleteLater`. However, when attempting to free resources immediately after script execution (in `PythonEngineWorker::doRun()`), calls to `QCoreApplication::processEvents` reset the `interrupt` flag set by `mWorkerThread->quit()`. As a result, `QEventLoop::exec` [calls](https://github.com/qt/qtbase/blob/7a7804d4b454021d68d1d5138d134ef62abfcdb3/src/corelib/kernel/qeventloop.cpp#L195) bloking [`MsgWaitForMultipleObjectsEx`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-msgwaitformultipleobjectsex)  (via `QEventDispatcherWin32::processEvents`)  with the [`INFINITE`](https://github.com/qt/qtbase/blob/7a7804d4b454021d68d1d5138d134ef62abfcdb3/src/corelib/kernel/qeventdispatcher_win.cpp#L549) flag (specifically for `QEventLoop::WaitForMoreEvents`), which leads to waiting for a [`PostMessage`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-postmessagea) call that can be triggered by `QEventLoop::wakeUp`, ` QAbstractEventDispatcher::interrupt`, or re-calling `qthread->quit`. Calls to` QCoreApplication::processEvents` with `QEventLoop::WaitForMoreEvents` generate the `QAbstractEventDispatcher::aboutToBlock` signal. This solution should not introduce regression because all current calls to `QCoreApplication::processEvents` occur with `QEventLoop::AllEvents` and will not be canceled.

