### PR TITLE
Fix deadlock or crash on Python script interruption

### DIFF
--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -42,7 +42,13 @@ static void abortPythonInterpreter() {
 	if(!Py_IsInitialized()) {
 		return;
 	}
+#if PY_VERSION_HEX < 0x03090000
 	Py_AddPendingCall(&quitFromPython, nullptr);
+#else
+	// https://github.com/python/cpython/issues/95820
+	PythonQtGILScope _;
+	Py_AddPendingCall(&quitFromPython, nullptr);
+#endif
 }
 
 PythonEngineWorker::PythonEngineWorker(trikControl::BrickInterface *brick

--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -33,12 +33,6 @@ using namespace trikScriptRunner;
 
 QAtomicInt PythonEngineWorker::initCounter = 0;
 
-extern "C" {
-	void _PyEval_AddPendingCall(PyInterpreterState *interp,
-	                            int (*func)(void *), void *arg,
-	                            int mainthreadonly);
-}
-
 static int quitFromPython(void*) {
 	PyErr_SetInterrupt();
 	return 0;
@@ -51,8 +45,10 @@ static void abortPythonInterpreter() {
 #if PY_VERSION_HEX < 0x03090000
 	Py_AddPendingCall(&quitFromPython, nullptr);
 #else
-	PyInterpreterState *interp = PyInterpreterState_Main();
-	_PyEval_AddPendingCall(interp, &quitFromPython, nullptr, 0);
+	Py_AddPendingCall(&quitFromPython, nullptr);
+	{
+		PythonQtGILScope _;
+	}
 #endif
 }
 

--- a/trikScriptRunner/src/pythonEngineWorker.cpp
+++ b/trikScriptRunner/src/pythonEngineWorker.cpp
@@ -42,13 +42,12 @@ static void abortPythonInterpreter() {
 	if(!Py_IsInitialized()) {
 		return;
 	}
-#if PY_VERSION_HEX < 0x03090000
+// 1. `Py_AddPendingCall` does not require `GIL` and `PythonQtGILScope _` before it,
+// and causes a lock when trying to stop the script because the `GIL`  is be held by instructions from the user script.
 	Py_AddPendingCall(&quitFromPython, nullptr);
-#else
-	Py_AddPendingCall(&quitFromPython, nullptr);
-	{
-		PythonQtGILScope _;
-	}
+#if PY_VERSION_HEX >= 0x03090000
+// 2. More correct recovery after handling `PyErr_SetInterrupt` while holding the `GIL`.
+	PythonQtGILScope _;
 #endif
 }
 


### PR DESCRIPTION
Although the main interpreter thread executes PythonEngineWorker under the GIL after PyEval_InitThreads, upon interrupting the script with SIGINT, the current thread ends up in a state without holding the GIL.

1. `Py_AddPendingCall` does not require `GIL` and `PythonQtGILScope _` before it, and causes a lock when trying to stop the script because the `GIL`  is held by instructions from the user script.
2. More correct recovery after handling `PyErr_SetInterrupt` while holding the `GIL`

Update:
Use `_PyEval_AddPendingCall` in a specific mode to ensure that `COMPUTE_EVAL_BREAKER` 
`&ceval2->pending.calls_to_do` is equal to 1. Perhaps a more natural solution is to use `PythonQtGilScope`, as `COMPUTE_EVAL_BREAKER` first looks at `&ceval2->gil_drop_request` and sets `eval_breaker` to 1, which is then checked when interpreting the bytecode (for example, in `JUMP_BACKWARD` and `CALL` instructions).

Update:
Use `PythonQtGilScope`