### PR TITLE
Fix for linux 4.14 for servos and US sensor

### DIFF
--- a/tests/kernel-4.14/test-system-config.xml
+++ b/tests/kernel-4.14/test-system-config.xml
@@ -96,21 +96,18 @@ equal to its class name.
 			deviceFile="/sys/class/pwm/ecap.2/duty_ns"
 			periodFile="/sys/class/pwm/ecap.2/period_ns"
 			runFile="/sys/class/pwm/ecap.2/run"
-			captureFile="/sys/class/pwm/ecap.2/capture"
 		/>
 		<servoMotor
 			port="S2"
 			deviceFile="/sys/class/pwm/ecap.1/duty_ns"
 			periodFile="/sys/class/pwm/ecap.1/period_ns"
 			runFile="/sys/class/pwm/ecap.1/run"
-			captureFile="/sys/class/pwm/ecap.1/capture"
 		/>
 		<servoMotor
 			port="S3"
 			deviceFile="/sys/class/pwm/ecap.0/duty_ns"
 			periodFile="/sys/class/pwm/ecap.0/period_ns"
 			runFile="/sys/class/pwm/ecap.0/run"
-			captureFile="/sys/class/pwm/ecap.0/capture"
 		/>
 		<servoMotor
 			port="S4"
@@ -164,9 +161,9 @@ equal to its class name.
 		<encoder port="E2" i2cCommandNumber="0x31" invert="true" />
 		<encoder port="E3" i2cCommandNumber="0x33" />
 		<encoder port="E4" i2cCommandNumber="0x32" invert="true" />
-		<rangeSensor port="D1" eventFile="/dev/input/by-path/platform-trik_jd1-event" module="jd1_hcsr04" />
-		<rangeSensor port="D2" eventFile="/dev/input/by-path/platform-trik_jd2-event" module="jd2_hcsr04" />
-		<rangeSensor port="D3" eventFile="/dev/input/by-path/platform-trik_jf1-event" module="jf1_hcsr04" />
+		<rangeSensor port="D1" eventFile="/dev/input/by-path/platform-trik_jd1-event" module="hcsr04" />
+		<rangeSensor port="D2" eventFile="/dev/input/by-path/platform-trik_jd2-event" module="hcsr04" />
+		<rangeSensor port="D3" eventFile="/dev/input/by-path/platform-trik_jf1-event" module="hcsr04" />
 		<!-- <digitalSensor port="D3" deviceFile="/sys/devices/platform/da850_trik/sensor_dc" /> -->
 		<lineSensor port="video1" />
 		<lineSensor port="video2" />

--- a/trikControl/configs/kernel-4.14/system-config.xml
+++ b/trikControl/configs/kernel-4.14/system-config.xml
@@ -95,21 +95,18 @@ equal to its class name.
 			deviceFile="/sys/class/pwm/pwmchip2/pwm0/duty_cycle"
 			periodFile="/sys/class/pwm/pwmchip2/pwm0/period"
 			runFile="/sys/class/pwm/pwmchip2/pwm0/enable"
-                        captureFile="/sys/class/pwm/pwmchip2/pwm0/capture"
 		/>
 		<servoMotor
 			port="S2"
 			deviceFile="/sys/class/pwm/pwmchip1/pwm0/duty_cycle"
 			periodFile="/sys/class/pwm/pwmchip1/pwm0/period"
 			runFile="/sys/class/pwm/pwmchip1/pwm0/enable"
-                        captureFile="/sys/class/pwm/pwmchip1/pwm0/capture"
 		/>
 		<servoMotor
 			port="S3"
 			deviceFile="/sys/class/pwm/pwmchip0/pwm0/duty_cycle"
 			periodFile="/sys/class/pwm/pwmchip0/pwm0/period"
 			runFile="/sys/class/pwm/pwmchip0/pwm0/enable"
-                        captureFile="/sys/class/pwm/pwmchip0/pwm0/capture"
 		/>
 		<servoMotor
 			port="S4"
@@ -163,9 +160,9 @@ equal to its class name.
 		<encoder port="E2" i2cCommandNumber="0x31" invert="true" />
 		<encoder port="E3" i2cCommandNumber="0x33" />
 		<encoder port="E4" i2cCommandNumber="0x32" invert="true" />
-		<rangeSensor port="D1" eventFile="/dev/input/by-path/platform-trik_jd1-event" module="jd1_hcsr04" />
-		<rangeSensor port="D2" eventFile="/dev/input/by-path/platform-trik_jd2-event" module="jd2_hcsr04" />
-		<rangeSensor port="D3" eventFile="/dev/input/by-path/platform-trik_jf1-event" module="jf1_hcsr04" />
+                <rangeSensor port="D1" eventFile="/dev/input/by-path/platform-trik_jd1-event" module="hcsr04" />
+                <rangeSensor port="D2" eventFile="/dev/input/by-path/platform-trik_jd2-event" module="hcsr04" />
+                <rangeSensor port="D3" eventFile="/dev/input/by-path/platform-trik_jf1-event" module="hcsr04" />
 		<!-- <digitalSensor port="D3" deviceFile="/sys/devices/platform/da850_trik/sensor_dc" /> -->
 		<lineSensor port="video1" />
 		<lineSensor port="video2" />


### PR DESCRIPTION
Changed the names of the module for the US sensor.

Deleted the file path for capture mode, as capture mode is not supported on version 4.14 yet.