### PR TITLE
Add check for v4l2 pixelformat (NV16) and remove camera settings for linux 4.14

### DIFF
--- a/trikControl/configs/kernel-4.14/system-config.xml
+++ b/trikControl/configs/kernel-4.14/system-config.xml
@@ -23,7 +23,8 @@ equal to its class name.
 <config version="model-2015" >
 	<!-- Initialization sh script, will be executed when runtime is launched. -->
 	<initScript>
-		/etc/trik/init-ov7670-320x240.sh 0
+                <!-- In linux 4.14 settings from this file are set in driver -->
+                # /etc/trik/init-ov7670-320x240.sh 0
 
 		echo 1 > /sys/bus/iio/devices/iio\:device0/scan_elements/in_timestamp_en
 		echo 1 > /sys/bus/iio/devices/iio\:device0/scan_elements/in_accel_x_en

--- a/trikControl/trikControl.pro
+++ b/trikControl/trikControl.pro
@@ -213,6 +213,7 @@ copyToDestdir( \
 
 trik_new_age {
     DEFINES += TRIK_IIO_ACCEL_GYRO
+    DEFINES += TRIK_NEW_OV7670
 }
 
 installs()

--- a/trikGui/startWidget.cpp
+++ b/trikGui/startWidget.cpp
@@ -118,8 +118,11 @@ void StartWidget::launch()
 	const QStandardItem * const currentItem = mMenuModel.itemFromIndex(currentIndex);
 	if (currentItem->hasChildren()) {
 		if (currentItem->text() == tr("Testing")) {
+#ifndef TRIK_NEW_OV7670
+			// In linux 4.14 settings from this file are set in driver
 			QProcess::startDetached("/etc/trik/init-ov7670-320x240.sh", {"0"});
 			QProcess::startDetached("/etc/trik/init-ov7670-320x240.sh", {"1"});
+#endif
 		}
 		setRootIndex(currentIndex);
 	} else {

--- a/trikHal/src/trik/trikV4l2VideoDevice.cpp
+++ b/trikHal/src/trik/trikV4l2VideoDevice.cpp
@@ -183,9 +183,12 @@ void TrikV4l2VideoDevice::setFormat()
 	mFormat.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 	mFormat.fmt.pix.width = 320;
 	mFormat.fmt.pix.height = 240;
+#ifdef TRIK_NEW_OV7670
+	mFormat.fmt.pix.pixelformat = V4L2_PIX_FMT_NV16; // will be resetted, if inappropriate
+#else
 	mFormat.fmt.pix.pixelformat = V4L2_PIX_FMT_YUV422P; // will be resetted, if inappropriate
+#endif
 	mFormat.fmt.pix.field = V4L2_FIELD_NONE;
-
 	char descPixelFmt[32] = {0}; // 32 - size of v4l2_fmtdesc.description
 	__u32 fmtIdx = 0;
 	do {
@@ -199,9 +202,10 @@ void TrikV4l2VideoDevice::setFormat()
 			memcpy(descPixelFmt, fmtTry.description, sizeof(descPixelFmt));
 
 			// have decoding of those formats:
+			// V4L2_PIX_FMT_NV16
 			// V4L2_PIX_FMT_YUV422P
 			// V4L2_PIX_FMT_YUYV
-			if (fmtTry.pixelformat == V4L2_PIX_FMT_YUV422P) {
+			if (fmtTry.pixelformat == V4L2_PIX_FMT_YUV422P || fmtTry.pixelformat == V4L2_PIX_FMT_NV16) {
 				QLOG_INFO() << "V4l2: found format V4L2_PIX_FMT_YUV422P";
 				mConvertFunc = yuv422pToRgb;
 				break;


### PR DESCRIPTION
1) Add check for v4l2 pixelformat (NV16)

2) Remove camera (ov7670) settings from bash scripts 