### PR TITLE
Reset socket notifiers before closing file descriptors

### DIFF
--- a/trikHal/src/trik/trikFifo.cpp
+++ b/trikHal/src/trik/trikFifo.cpp
@@ -119,6 +119,7 @@ void TrikFifo::readFile()
 bool TrikFifo::close()
 {
 	if (mFileDescriptor != -1) {
+		mSocketNotifier.reset();
 		bool result = ::close(mFileDescriptor) == 0;
 		mFileDescriptor = -1;
 		return result;

--- a/trikWiFi/src/trikWiFiWorker.cpp
+++ b/trikWiFi/src/trikWiFiWorker.cpp
@@ -74,6 +74,7 @@ void TrikWiFiWorker::dispose()
 		mMonitorInterface->detach();
 	}
 
+	mMonitorFileSocketNotifier.reset();
 	mControlInterface.reset();
 	mMonitorInterface.reset();
 }


### PR DESCRIPTION
Without explicitly resetting QSocketNotifier before closing the underlying file descriptor, the notifier continues to watch an already-invalid fd, leading to errors and segfaults.