### PR TITLE
Fix connection to the selected WiFi SSID.

### DIFF
--- a/trikWiFi/src/trikWiFi.cpp
+++ b/trikWiFi/src/trikWiFi.cpp
@@ -106,7 +106,7 @@ SignalStrength TrikWiFi::signalStrength()
 
 void TrikWiFi::connect(const QString &ssid)
 {
-	QMetaObject::invokeMethod(mWorker.data(), [this, &ssid](){mWorker->connect(ssid);});
+	QMetaObject::invokeMethod(mWorker.data(), [this, ssid](){mWorker->connect(ssid);});
 }
 
 void TrikWiFi::disconnect()


### PR DESCRIPTION
Cannot pass ssid by reference to a lambda function running in a separate thread.

When the thread that called invokeMethod finishes, it will destroy the reference, and if this happens before the reference is accessed in the spawned thread, a segfault will occur since the variable will have already been destroyed.

Therefore, a copy must be made.