### PR TITLE
Fix use-after-free, memory leaks and off-by-one in recv buffer

### DIFF
--- a/trikGui/mainMenuManager.cpp
+++ b/trikGui/mainMenuManager.cpp
@@ -81,7 +81,11 @@ MainMenuManager::MainMenuManager(const QString &configPath, QQmlApplicationEngin
 	mController.brick().playTone(2000, 150);
 }
 
-MainMenuManager::~MainMenuManager() {}
+MainMenuManager::~MainMenuManager() {
+	// MainMenuManager children (e.g. WiFiIndicator) must die before mController destroys his 
+	// members (f.e. TrikWiFi), otherwise QML timer callbacks still call isConnected() on freed memory.
+	qDeleteAll(children());
+}
 
 void MainMenuManager::createApp(AppType appType) {
 	switch (appType) {

--- a/trikGui/mainMenuManager.cpp
+++ b/trikGui/mainMenuManager.cpp
@@ -28,7 +28,6 @@
 #include "openSocketIndicator.h"
 #include "testingManager.h"
 #include "wiFiIndicator.h"
-#include "trikGuiApplication.h"
 #include <QProcess>
 #include <QQmlContext>
 #include "fileManager.h"
@@ -40,8 +39,8 @@
 #include <QExposeEvent>
 
 using namespace trikGui;
-MainMenuManager::MainMenuManager(const QString &configPath, QQmlApplicationEngine *engine, QObject *parent)
-	: QObject(parent), mController(configPath), mEngine(engine)
+MainMenuManager::MainMenuManager(const QString &configPath, QQmlApplicationEngine *engine, TrikGuiApplication *trikGuiApp)
+	: QObject(trikGuiApp), mController(configPath), mEngine(engine)
 	, mFileManagerRoot(SystemSettings::FileManagerRootType::ScriptsDir) {
 	qmlRegisterTypesAndRevisions<MainMenuManager>("com.trikGui", 1);
 	qmlRegisterTypesAndRevisions<TestingManager>("com.trikGui", 1);
@@ -74,9 +73,8 @@ MainMenuManager::MainMenuManager(const QString &configPath, QQmlApplicationEngin
 	qmlRegisterSingletonInstance<OpenSocketIndicator>("com.trikGui", 1, 0, "CommunicatorIndicator",
 							  communicatorIndicator);
 
-	auto *trikApp = qobject_cast<TrikGuiApplication *>(qApp);
-	connect(trikApp, &TrikGuiApplication::showPowerConfirm, this, &MainMenuManager::showPowerConfirm);
-	connect(trikApp, &TrikGuiApplication::hidePowerConfirm, this, &MainMenuManager::hidePowerConfirm);
+	connect(trikGuiApp, &TrikGuiApplication::showPowerConfirm, this, &MainMenuManager::showPowerConfirm);
+	connect(trikGuiApp, &TrikGuiApplication::hidePowerConfirm, this, &MainMenuManager::hidePowerConfirm);
 
 	mController.brick().playTone(2000, 150);
 }
@@ -90,29 +88,29 @@ MainMenuManager::~MainMenuManager() {
 void MainMenuManager::createApp(AppType appType) {
 	switch (appType) {
 	case AppType::Files: {
-		FileManager *fileManager = new FileManager(mController, mFileManagerRoot, this);
+		auto *fileManager = new FileManager(mController, mFileManagerRoot, this);
 		mEngine->rootContext()->setContextProperty("FileManagerServer", fileManager);
 		break;
 	}
 	case AppType::Testing: {
 		QProcess::startDetached("/etc/trik/init-ov7670-320x240.sh", {"0"});
 		QProcess::startDetached("/etc/trik/init-ov7670-320x240.sh", {"1"});
-		TestingManager *testingManager = new TestingManager(mController, mEngine, this);
+		auto *testingManager = new TestingManager(mController, mEngine, this);
 		mEngine->rootContext()->setContextProperty("TestingManager", testingManager);
 		break;
 	}
 	case AppType::Network: {
 #ifndef DESKTOP
-		WiFiMode *wiFiMode = new WiFiMode(mController.wiFi(), mEngine, this);
+		auto *wiFiMode = new WiFiMode(mController.wiFi(), mEngine, this);
 #else
-		WiFiModeMock *wiFiMode = new WiFiModeMock(mEngine, this);
+		auto *wiFiMode = new WiFiModeMock(mEngine, this);
 #endif
 		mEngine->rootContext()->setContextProperty("WiFiModeServer", wiFiMode);
 		break;
 	}
 	case AppType::CommSettings: {
 		if (mController.mailbox()) {
-			CommunicationSettings *communicationSettings =
+			auto *communicationSettings =
 			    new CommunicationSettings(*mController.mailbox(), this);
 			mEngine->rootContext()->setContextProperty("CommunicationSettingsServer",
 								   communicationSettings);

--- a/trikGui/mainMenuManager.h
+++ b/trikGui/mainMenuManager.h
@@ -18,6 +18,7 @@
 #include <QObject>
 #include <QQmlApplicationEngine>
 #include <QtQml/qqml.h>
+#include "trikGuiApplication.h"
 
 namespace trikGui {
 
@@ -29,8 +30,8 @@ class MainMenuManager : public QObject
 	QML_UNCREATABLE("Use MainMenuManager singleton")
 public:
 	/// Constructor
-	explicit MainMenuManager(const QString &configPath, QQmlApplicationEngine *engine, QObject *parent = nullptr);
-	~MainMenuManager();
+	explicit MainMenuManager(const QString &configPath, QQmlApplicationEngine *engine, TrikGuiApplication *trikGuiApp);
+	~MainMenuManager() override;
 	enum class AppType {
 		Files,
 		Testing,

--- a/trikGui/qml/Testing.qml
+++ b/trikGui/qml/Testing.qml
@@ -10,35 +10,11 @@ Rectangle {
     property var idList: _listTesting
     color: activeTheme.backgroundColor
     Component.onCompleted: {
-        // testingManager.configureVideoModule();
         testingManager.setQmlParent(_mainItem);
     }
 
     ListModel {
         id: dataModelTesting
-
-        // ListElement {
-        //     iconPath: "analog.png"
-        //     filePath: "AnalogDigitalSensors.qml"
-        //     text: qsTr("Analog sensors")
-        //     type: Type.AnalogSensor
-        // }
-        // ListElement {
-        //     iconPath: "digital.png"
-        //     filePath: "AnalogDigitalSensors.qml"
-        //     text: qsTr("Digital sensors")
-        //     type: Type.DigitalSensor
-        // }
-        // Component.onCompleted: {
-        //     if (testingManager.checkPwmCapture()) {
-        //         dataModelTesting.insert(1, {
-        //             "iconPath": "pwmcapture.png",
-        //             "filePath": "AnalogDigitalSensors.qml",
-        //             "text": qsTr("PWM capture"),
-        //             "type": Type.PwmCapture
-        //         });
-        //     }
-        // }
 
         ListElement {
             iconPath: "digital.png"

--- a/trikGui/testingManager.cpp
+++ b/trikGui/testingManager.cpp
@@ -22,9 +22,6 @@ TestingManager::TestingManager(Controller &controller, QQmlApplicationEngine *en
 	: QObject(parent), mController(controller), mEngine(engine) {
 }
 
-TestingManager::~TestingManager() {
-}
-
 void TestingManager::createSensors(SensorType type) {
 	QStringList ports;
 	switch (static_cast<Sensors::SensorType>(type)) {
@@ -46,7 +43,7 @@ void TestingManager::createSensors(SensorType type) {
 	default:
 		break;
 	}
-	Sensors *sensors = new Sensors(mController.brick(), ports, static_cast<Sensors::SensorType>(type), mEngine, this);
+	auto *sensors = new Sensors(mController.brick(), ports, static_cast<Sensors::SensorType>(type), mEngine, this);
 	mEngine->rootContext()->setContextProperty("Sensors", sensors);
 }
 
@@ -64,18 +61,12 @@ void TestingManager::createMotors(MotorType type) {
 	default:
 		break;
 	}
-	Motors *motors = new Motors(mController.brick(), ports, this);
+	auto *motors = new Motors(mController.brick(), ports, this);
 	mEngine->rootContext()->setContextProperty("MotorsManager", motors);
 }
 
 void TestingManager::setQmlParent(QObject *parent) {
 	setParent(parent);
-}
-
-void TestingManager::configureVideoModule()
-{
-	QProcess::startDetached("/etc/trik/init-ov7670-320x240.sh", {"0"});
-	QProcess::startDetached("/etc/trik/init-ov7670-320x240.sh", {"1"});
 }
 
 bool TestingManager::checkPwmCapture() { return mController.brick().pwmCapturePorts().length() != 0; }

--- a/trikGui/testingManager.h
+++ b/trikGui/testingManager.h
@@ -31,7 +31,7 @@ class TestingManager : public QObject
 public:
 	/// Constructor
 	explicit TestingManager(Controller &controller, QQmlApplicationEngine *engine, QObject *parent = nullptr);
-	~TestingManager();
+	~TestingManager() override = default;
 
 	enum class MotorType {
 		PowerMotor = static_cast<int>(Motors::MotorType::PowerMotor),
@@ -56,8 +56,6 @@ public:
 	Q_INVOKABLE void setQmlParent(QObject *parent);
 
 	Q_INVOKABLE bool checkPwmCapture();
-
-	Q_INVOKABLE void configureVideoModule();
 
 private:
 	Controller &mController;

--- a/trikGui/trikGuiMain.cpp
+++ b/trikGui/trikGuiMain.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 
 	QLOG_INFO() << "TrikGui started";
 
-	MainMenuManager mainMenuManager(initHelper.configPath(), engine);
+	MainMenuManager mainMenuManager(initHelper.configPath(), engine, &app);
 	const QUrl url(QStringLiteral("qrc:/qml/main.qml"));
 	QObject::connect(
 		engine, &QQmlApplicationEngine::objectCreated, &app,

--- a/trikKernel/src/translationsHelper.cpp
+++ b/trikKernel/src/translationsHelper.cpp
@@ -44,7 +44,7 @@ void TranslationsHelper::loadTranslators(const QString &locale)
 		const QFileInfo &translatorFile = QFileInfo(files.next());
 		if (translatorFile.isFile() && translatorFile.baseName().split('_').at(1) == locale) {
 			QLOG_INFO() << "Loading translations from" << translatorFile.absoluteFilePath();
-			QTranslator *translator = new QTranslator(nullptr);
+			auto *translator = new QTranslator(qApp);
 			translator->load(translatorFile.absoluteFilePath());
 			QCoreApplication::installTranslator(translator);
 			gInstalledTranslators.append(translator);

--- a/trikWiFi/src/wpaSupplicantCommunicator.cpp
+++ b/trikWiFi/src/wpaSupplicantCommunicator.cpp
@@ -143,7 +143,7 @@ int WpaSupplicantCommunicator::request(const QString &command, QString &reply)
 		if (FD_ISSET(mSocket, &rfds)) {
 			const int bufferSize = 2048;
 			char buffer[bufferSize];
-			auto replyLen = recv(mSocket, buffer, bufferSize, 0);
+			auto replyLen = recv(mSocket, buffer, bufferSize - 1, 0);
 			if (replyLen < 0) {
 				QLOG_ERROR() << "Cannot receive a reply from the daemon:" << strerror(errno);
 				return -1;

--- a/trikWiFi/src/wpaSupplicantCommunicator.cpp
+++ b/trikWiFi/src/wpaSupplicantCommunicator.cpp
@@ -80,12 +80,12 @@ WpaSupplicantCommunicator::~WpaSupplicantCommunicator()
 	}
 }
 
-int WpaSupplicantCommunicator::fileDescriptor()
+int WpaSupplicantCommunicator::fileDescriptor() const
 {
 	return mSocket;
 }
 
-int WpaSupplicantCommunicator::attach()
+int WpaSupplicantCommunicator::attach() const
 {
 	if (mSocket < 0) {
 		QLOG_ERROR() << __PRETTY_FUNCTION__ <<  "Cannot attach, because socket doesn't exist.";
@@ -102,7 +102,7 @@ int WpaSupplicantCommunicator::attach()
 	}
 }
 
-int WpaSupplicantCommunicator::detach()
+int WpaSupplicantCommunicator::detach() const
 {
 	if (mSocket < 0) {
 		QLOG_ERROR() << __PRETTY_FUNCTION__ << "Cannot detach, because socket doesn't exist.";
@@ -119,7 +119,7 @@ int WpaSupplicantCommunicator::detach()
 	}
 }
 
-int WpaSupplicantCommunicator::request(const QString &command, QString &reply)
+int WpaSupplicantCommunicator::request(const QString &command, QString &reply) const
 {
 	if (mSocket < 0) {
 		QLOG_ERROR() << __PRETTY_FUNCTION__ << "Cannot request, because socket doesn't exist.";
@@ -161,7 +161,7 @@ int WpaSupplicantCommunicator::request(const QString &command, QString &reply)
 	}
 }
 
-bool WpaSupplicantCommunicator::isPending()
+bool WpaSupplicantCommunicator::isPending() const
 {
 	struct timeval tv {};
 	fd_set rfds;
@@ -173,11 +173,11 @@ bool WpaSupplicantCommunicator::isPending()
 	return FD_ISSET(mSocket, &rfds);
 }
 
-int WpaSupplicantCommunicator::receive(QString &message)
+int WpaSupplicantCommunicator::receive(QString &message) const
 {
 	const int bufferSize = 256;
 	char buffer[bufferSize];
-	const int messageLen = recv(mSocket, buffer, bufferSize, 0);
+	const ssize_t messageLen = recv(mSocket, buffer, bufferSize - 1, 0);
 	if (messageLen < 0) {
 		QLOG_ERROR() << "Cannot receive a message from the daemon:" << strerror(errno);
 		return -1;

--- a/trikWiFi/src/wpaSupplicantCommunicator.h
+++ b/trikWiFi/src/wpaSupplicantCommunicator.h
@@ -37,28 +37,28 @@ public:
 	WpaSupplicantCommunicator(const QString &interfaceFile, const QString &daemonFile, QObject *parent = nullptr);
 
 	/// Destructor.
-	~WpaSupplicantCommunicator();
+	~WpaSupplicantCommunicator() override;
 
 	/// Handle of a file
-	int fileDescriptor();
+	int fileDescriptor() const;
 
 	/// Attach communicator to wpa_supplicant to be able to receive network events.
-	int attach();
+	int attach() const;
 
 	/// Detach communicator from wpa_supplicant.
-	int detach();
+	int detach() const;
 
 	/// Send a request to wpa_supplicant.
 	/// @param command - command to wpa_supplicant. List of available commands is here:
 	///        http://hostap.epitest.fi/wpa_supplicant/devel/ctrl_iface_page.html
 	/// @param reply - reply from wpa_supplicant.
-	int request(const QString &command, QString &reply);
+	int request(const QString &command, QString &reply) const;
 
 	/// Returns true if there are unread incoming messages from wpa_supplicant.
-	bool isPending();
+	bool isPending() const;
 
 	/// Receive next incoming message from wpa_supplicant.
-	int receive(QString &message);
+	int receive(QString &message) const;
 
 private:
 	int mSocket;

--- a/trikWiFi/src/wpaSupplicantCommunicator_stub.cpp
+++ b/trikWiFi/src/wpaSupplicantCommunicator_stub.cpp
@@ -27,6 +27,7 @@ WpaSupplicantCommunicator::WpaSupplicantCommunicator(
 		, QObject *parent
 		)
 	: QObject(parent)
+	, mSocket(-1)
 	, mLocal(new sockaddr_un())
 	, mDest(new sockaddr_un())
 {
@@ -34,26 +35,24 @@ WpaSupplicantCommunicator::WpaSupplicantCommunicator(
 	Q_UNUSED(daemonFile);
 }
 
-WpaSupplicantCommunicator::~WpaSupplicantCommunicator()
-{
-}
+WpaSupplicantCommunicator::~WpaSupplicantCommunicator() = default;
 
-int WpaSupplicantCommunicator::fileDescriptor()
+int WpaSupplicantCommunicator::fileDescriptor() const
 {
 	return -1;
 }
 
-int WpaSupplicantCommunicator::attach()
+int WpaSupplicantCommunicator::attach() const
 {
 	return -1;
 }
 
-int WpaSupplicantCommunicator::detach()
+int WpaSupplicantCommunicator::detach() const
 {
 	return -1;
 }
 
-int WpaSupplicantCommunicator::request(const QString &command, QString &reply)
+int WpaSupplicantCommunicator::request(const QString &command, QString &reply) const
 {
 	Q_UNUSED(command);
 	Q_UNUSED(reply);
@@ -61,12 +60,12 @@ int WpaSupplicantCommunicator::request(const QString &command, QString &reply)
 	return -1;
 }
 
-bool WpaSupplicantCommunicator::isPending()
+bool WpaSupplicantCommunicator::isPending() const
 {
 	return false;
 }
 
-int WpaSupplicantCommunicator::receive(QString &message)
+int WpaSupplicantCommunicator::receive(QString &message) const
 {
 	Q_UNUSED(message);
 


### PR DESCRIPTION
1. Explicitly delete Qt children of MainMenuManager before mController destroys TrikWiFi, preventing QML timer callbacks from calling isConnected() on freed memory

2. Pass qApp as parent to QTranslator to fix memory leak

3. Pass bufferSize - 1 to recv() to prevent off-by-one buffer overflow if reply exactly fills the 2048-byte buffer