### PR TITLE
Fix WiFi mode switch cancellation: restoring previous network state on Escape

### DIFF
--- a/translations/trikRuntime_de.ts
+++ b/translations/trikRuntime_de.ts
@@ -509,6 +509,10 @@
 <context>
     <name>WiFiInit</name>
     <message>
+        <source>Restoring previous network mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Network initialization in process</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/trikRuntime_fr.ts
+++ b/translations/trikRuntime_fr.ts
@@ -502,6 +502,10 @@
 <context>
     <name>WiFiInit</name>
     <message>
+        <source>Restoring previous network mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Network initialization in process</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/trikRuntime_ru.ts
+++ b/translations/trikRuntime_ru.ts
@@ -624,6 +624,10 @@
         <source>Press Escape for break</source>
         <translation>Нажмите Escape, чтобы выйти</translation>
     </message>
+    <message>
+        <source>Restoring previous network mode</source>
+        <translation>Восстановление режима сети</translation>
+    </message>
 </context>
 <context>
     <name>WiFiMode</name>

--- a/trikGui/qml/WiFiInit.qml
+++ b/trikGui/qml/WiFiInit.qml
@@ -3,25 +3,30 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 Rectangle {
+    id: _mainItem
     color: activeTheme.backgroundColor
     property var wiFiInit: WiFiInitServer
+
+    Component.onCompleted: {
+        wiFiInit.setQmlParent(_mainItem);
+    }
 
     Keys.onPressed: {
         switch (event.key) {
         case Qt.Key_Escape:
-            wiFiInit.exit()
-            event.accepted = true
-            break
+            wiFiInit.exit();
+            event.accepted = true;
+            break;
         case Qt.Key_PowerOff:
-            event.accepted = true
-            break
+            event.accepted = true;
+            break;
         case Qt.Key_W:
             if (event.modifiers & Qt.ControlModifier) {
-                event.accepted = true
+                event.accepted = true;
             }
-            break
+            break;
         default:
-            break
+            break;
         }
     }
     ColumnLayout {
@@ -31,9 +36,10 @@ Rectangle {
         spacing: 10
 
         Text {
-            text: qsTr("Network initialization in process")
+            text: wiFiInit.restoring ? qsTr("Restoring previous network mode") : qsTr("Network initialization in process")
             wrapMode: Text.Wrap
             Layout.fillWidth: true
+            Layout.preferredHeight: font.pixelSize * 4
             horizontalAlignment: Text.AlignHCenter
             font.pointSize: fontSizes.medium
             color: activeTheme.textColor

--- a/trikGui/qml/WiFiMode.qml
+++ b/trikGui/qml/WiFiMode.qml
@@ -10,15 +10,14 @@ Rectangle {
     property var wiFiSelectionComponent: null
     color: activeTheme.backgroundColor
     Component.onCompleted: {
-        wiFiMode.setQmlParent(_mainItem)
-
-        var currentMode = wiFiMode.currentMode()
+        wiFiMode.setQmlParent(_mainItem);
+        var currentMode = wiFiMode.currentMode();
         if (currentMode === Mode.Client) {
-            wiFiMode.setMode(Mode.Client)
+            wiFiMode.setMode(Mode.Client);
         } else if (currentMode === Mode.AccessPoint) {
-            wiFiMode.setMode(Mode.AccessPoint)
+            wiFiMode.setMode(Mode.AccessPoint);
         } else {
-            pageLoader.setSource("WiFiModeSelection.qml")
+            pageLoader.setSource("WiFiModeSelection.qml");
         }
     }
     Loader {
@@ -26,9 +25,9 @@ Rectangle {
         anchors.fill: parent
         onLoaded: {
             if (pageLoader.item.idList) {
-                pageLoader.item.idList.focus = true
+                pageLoader.item.idList.focus = true;
             } else {
-                pageLoader.item.focus = true
+                pageLoader.item.focus = true;
             }
         }
     }
@@ -38,19 +37,17 @@ Rectangle {
         function onInitStatusChanged() {
             switch (wiFiMode.initStatus) {
             case "start":
-                pageLoader.setSource("WiFiInit.qml")
-                break
+                pageLoader.setSource("WiFiInit.qml");
+                break;
             case "WiFiClient":
-                pageLoader.setSource("WiFiClient.qml")
-                break
+                pageLoader.setSource("WiFiClient.qml");
+                break;
             case "WiFiAP":
-                pageLoader.setSource("WiFiAP.qml")
-                break
+                pageLoader.setSource("WiFiAP.qml");
+                break;
             case "error":
-                stack.currentItem.destroy()
-                stack.pop()
-                stack.currentItem.idList.focus = true
-                break
+                root.navigateBack();
+                break;
             }
         }
     }

--- a/trikGui/qml/main.qml
+++ b/trikGui/qml/main.qml
@@ -18,6 +18,15 @@ ApplicationWindow {
     property var activeTheme: ThemeMode === "light" ? _lightTheme : _darkTheme
     property var fontSizes: _fontSizes
 
+    function navigateBack() {
+        if (stack.depth > 1) {
+            stack.pop();
+            if (stack.currentItem && stack.currentItem.idList) {
+                stack.currentItem.idList.focus = true;
+            }
+        }
+    }
+
     LightTheme {
         id: _lightTheme
     }

--- a/trikGui/wiFiInit.cpp
+++ b/trikGui/wiFiInit.cpp
@@ -24,16 +24,15 @@ using namespace trikGui;
 WiFiInit::WiFiInit(QObject *parent) : QObject(parent) {
 	connect(&mProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
 		&WiFiInit::onProcessFinished);
-	connect(&mProcess, QOverload<QProcess::ProcessError>::of(&QProcess::errorOccurred), this,
-		&WiFiInit::onProcessError);
 	connect(&mProcess, &QProcess::errorOccurred, this, &WiFiInit::onProcessError);
 }
 
 WiFiInit::~WiFiInit() {
 	if (mProcess.state() != QProcess::NotRunning) {
-		QLOG_ERROR() << "Destroyng WiFiInitWidget with runnig process. The user "
-				"has cancelled the running operation?";
-		mProcess.kill();
+		// Should not happen: init() waits for the process via event loop.
+		QLOG_ERROR() << "WiFiInit destroyed with running process";
+		mProcess.terminate();
+		mProcess.waitForFinished(5000);
 	}
 }
 
@@ -51,45 +50,61 @@ WiFiInit::Result WiFiInit::init(WiFiMode::Mode mode) {
 		break;
 	}
 	case WiFiMode::Mode::Unknown: {
-		QLOG_ERROR() << "Error: unknown WiFi mode in WiFiInitWidget::init()";
+		QLOG_ERROR() << "Error: unknown WiFi mode in WiFiInit::init()";
 		return Result::fail;
 	}
 	}
 
 	mProcess.start(command, arguments);
 
-	const int result = mEventLoop.exec();
-
-	if (result != 0) {
-		return Result::fail;
-	}
-
-	return Result::success;
+	// Blocks here, processing Qt events, until onProcessFinished exits the loop.
+	// exit() sends SIGTERM but does NOT exit the loop — we keep waiting for
+	// sigterm_handler to finish restoring the previous network mode.
+	const int code = mEventLoop.exec();
+	return static_cast<Result>(code);
 }
 
 void WiFiInit::exit() {
-	mProcess.disconnect();
-	mProcess.kill();
-	mEventLoop.exit(1);
+	if (mProcess.state() != QProcess::NotRunning) {
+		mRestoring = true;
+		Q_EMIT restoringChanged();
+		// Do NOT exit the event loop — we keep running until sigterm_handler
+		// finishes restoring the previous network mode.
+		mProcess.terminate();
+	}
 }
 
-void WiFiInit::onProcessFinished(int, QProcess::ExitStatus exitStatus) {
+void WiFiInit::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus) {
 	mProcess.disconnect();
 
-	switch (exitStatus) {
-	case QProcess::NormalExit: {
-		mEventLoop.exit(0);
-		break;
+	if (exitStatus == QProcess::CrashExit) {
+		mEventLoop.exit(static_cast<int>(Result::fail));
+		return;
 	}
-	case QProcess::CrashExit: {
-		mEventLoop.exit(1);
+
+	// exit codes from set_wifi_mode.sh:
+	//   0 — normal success
+	//   1 — script error
+	//   2 — cancelled by SIGTERM, sigterm_handler restored previous mode
+	switch (exitCode) {
+	case 0:
+		mEventLoop.exit(static_cast<int>(Result::success));
 		break;
-	}
+	case 2:
+		mEventLoop.exit(static_cast<int>(Result::cancelled));
+		break;
+	default:
+		mEventLoop.exit(static_cast<int>(Result::fail));
+		break;
 	}
 }
 
 void WiFiInit::onProcessError(QProcess::ProcessError error) {
 	mProcess.disconnect();
 	QLOG_ERROR() << "set_wifi_mode.sh process error: " << error;
-	mEventLoop.exit(1);
+	mEventLoop.exit(static_cast<int>(Result::fail));
+}
+
+void WiFiInit::setQmlParent(QObject *parent) {
+	setParent(parent);
 }

--- a/trikGui/wiFiInit.h
+++ b/trikGui/wiFiInit.h
@@ -36,23 +36,33 @@ public:
 	~WiFiInit() override;
 
 	enum class Result {
-		success
-		, fail
+		success   // script exited 0 — mode switch complete
+		, cancelled // user cancelled, sigterm_handler restored previous mode (exit 2)
+		, fail    // script error (exit 1 or crash)
 	};
+
+	Q_PROPERTY(bool restoring READ isRestoring NOTIFY restoringChanged)
+	bool isRestoring() const { return mRestoring; }
 
 	/// Initialize wi-fi on the controller.
 	/// @param mode - wi-fi mode which we want to initialize.
-	/// @return WiFiInitWidget::success if wi-fi was succesfully initialized and WiFiInitWidget::fail otherwise.
 	Result init(WiFiMode::Mode mode);
 
 	Q_INVOKABLE void exit();
 
+	Q_INVOKABLE void setQmlParent(QObject *parent);
+
+Q_SIGNALS:
+	void restoringChanged();
+
 private:
+	bool mRestoring = false;
+
 	QEventLoop mEventLoop;
 	QProcess mProcess;
 
 private Q_SLOTS:
-	void onProcessFinished(int, QProcess::ExitStatus exitStatus);
+	void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
 	void onProcessError(QProcess::ProcessError error);
 };
 

--- a/trikGui/wiFiMode.cpp
+++ b/trikGui/wiFiMode.cpp
@@ -29,13 +29,13 @@ WiFiMode::WiFiMode(trikWiFi::TrikWiFi &wiFi, QQmlApplicationEngine *engine, QObj
 	: QObject(parent), mWiFi(wiFi), mEngine(engine), mRcReader(trikKernel::Paths::trikRcName()) {}
 
 void WiFiMode::createWiFiClient() {
-	WiFiClient *wiFiClient = new WiFiClient(mWiFi, this);
+	auto *wiFiClient = new WiFiClient(mWiFi, this);
 	mEngine->rootContext()->setContextProperty("WiFiClientServer", wiFiClient);
 	wiFiClient->scanWiFi();
 }
 
 void WiFiMode::createWiFiAP() {
-	WiFiAP *wiFiAP = new WiFiAP(this);
+	auto *wiFiAP = new WiFiAP(this);
 	mEngine->rootContext()->setContextProperty("WiFiAPServer", wiFiAP);
 }
 
@@ -51,11 +51,26 @@ void WiFiMode::setMode(Mode mode) {
 	}
 
 	if (currentMode != mode) {
-		WiFiInit wiFiInit;
-		mEngine->rootContext()->setContextProperty("WiFiInitServer", &wiFiInit);
+		auto *wiFiInit = new WiFiInit(this);
+		mEngine->rootContext()->setContextProperty("WiFiInitServer", wiFiInit);
 		mInitStatus = "start";
 		Q_EMIT initStatusChanged();
-		if (wiFiInit.init(mode) == WiFiInit::Result::fail) {
+		const auto initResult = wiFiInit->init(mode);
+
+		if (initResult == WiFiInit::Result::cancelled) {
+			// User pressed Escape. bash sigterm_handler restored currentMode.
+			// Sync C++ WiFi state to match.
+			if (currentMode == Mode::Client) {
+				mWiFi.reinit();
+			} else if (currentMode == Mode::AccessPoint) {
+				mWiFi.dispose();
+			}
+			mInitStatus = "error";
+			Q_EMIT initStatusChanged();
+			return;
+		}
+
+		if (initResult == WiFiInit::Result::fail) {
 			QLOG_ERROR() << "Failed to init WiFi in mode" << currentModeText;
 			mInitStatus = "error";
 			Q_EMIT initStatusChanged();

--- a/trikWiFi/src/trikWiFiWorker.cpp
+++ b/trikWiFi/src/trikWiFiWorker.cpp
@@ -44,6 +44,15 @@ void TrikWiFiWorker::reinit()
 		mMonitorInterface->detach();
 	}
 
+	// destroy old communicators first so their destructors unlink the socket files
+	// before new communicators bind to the same paths
+	mMonitorFileSocketNotifier.reset();
+	mControlInterface.reset();
+	mMonitorInterface.reset();
+
+	// Pointers must be null here. WpaSupplicantCommunicator binds a UNIX socket file on construction
+	// and unlinks it on destruction. reset(new T) destroys the old object AFTER the new one binds,
+	// so the old destructor would unlink the new socket file — breaking network restoration.
 	mControlInterface.reset(new WpaSupplicantCommunicator(mInterfaceFile + "ctrl", mDaemonFile));
 	mMonitorInterface.reset(new WpaSupplicantCommunicator(mInterfaceFile + "mon", mDaemonFile));
 


### PR DESCRIPTION
1) Previously, pressing Escape during network initialization killed the bash script mid-execution, leaving wpa_supplicant/hostapd in an undefined state requiring manual re-initialization.

2) Now exit() sends SIGTERM to the bash script and keeps the Qt event loop running until sigterm_handler finishes restoring the previous mode. Exit code 2 from the script signals successful restoration, which is handled separately from a real error (exit 1) — C++ syncs its WiFi state

3) Also fixed a socket file race in TrikWiFiWorker::reinit() that caused 'No reply from daemon' after network restoration.