### PR TITLE
Fix UI RunningCodeComponent

### DIFF
--- a/trikGui/qml/MainMenu.qml
+++ b/trikGui/qml/MainMenu.qml
@@ -27,6 +27,15 @@ Rectangle {
         }
 
         function onShowRunningCodeComponent(programName) {
+            // If a RunningCodeComponent is already on the stack, replace it
+            // instead of pushing a second one (happens when a new script starts
+            // before the previous one's hide signal arrives).
+            if (runningCodeObject !== null) {
+                if (runningCodeObject === stack.currentItem) {
+                    stack.pop();
+                }
+                runningCodeObject = null;
+            }
             var page = stack.push("RunningCodeComponent.qml");
             if (page) {
                 if (programName === "direct command") {
@@ -84,18 +93,11 @@ Rectangle {
 
         function onHidden() {
             if (_mainMenuView.graphicsWidgetObject !== null && _mainMenuView.graphicsWidgetObject === stack.currentItem) {
-                // Defer pop out of GraphicsWidget's own signal emission to avoid
-                // "Object destroyed while signal handler is in progress" crash.
-                var saved = _mainMenuView.graphicsWidgetObject;
+                stack.pop();
                 _mainMenuView.graphicsWidgetObject = null;
-                Qt.callLater(function () {
-                    if (saved === stack.currentItem) {
-                        stack.pop();
-                        if (stack.currentItem && stack.currentItem.idList) {
-                            stack.currentItem.idList.focus = true;
-                        }
-                    }
-                });
+                if (stack.currentItem && stack.currentItem.idList) {
+                    stack.currentItem.idList.focus = true;
+                }
             } else {
                 _mainMenuView.graphicsWidgetObject = null;
             }


### PR DESCRIPTION
If a RunningCodeComponent is already on the stack, replace it instead of pushing a second one (happens when a new script starts before the previous one's hide signal arrives).