### PR TITLE
Fix image rendering in GraphicsWidget.

### DIFF
--- a/trikGui/qml/GraphicsWidgetComponent.qml
+++ b/trikGui/qml/GraphicsWidgetComponent.qml
@@ -5,17 +5,6 @@ Rectangle {
     id: _graphicsContainer
     color: "transparent"
 
-    Binding {
-        target: GraphicsWidget
-        property: "width"
-        value: _graphicsContainer.width
-    }
-    Binding {
-        target: GraphicsWidget
-        property: "height"
-        value: _graphicsContainer.height
-    }
-
     Component.onCompleted: {
         GraphicsWidget.parent = _graphicsContainer;
     }

--- a/trikGui/qml/MainMenu.qml
+++ b/trikGui/qml/MainMenu.qml
@@ -77,6 +77,19 @@ Rectangle {
         }
     }
 
+    // Set GraphicsWidget dimensions early, before the widget
+    // is drawn — required for correct image scaling in brick.display().showImage().
+    Binding {
+        target: GraphicsWidget
+        property: "width"
+        value: _mainMenuView.width
+    }
+    Binding {
+        target: GraphicsWidget
+        property: "height"
+        value: _mainMenuView.height
+    }
+
     Connections {
         target: GraphicsWidget
 

--- a/trikGui/qml/RunningCodeComponent.qml
+++ b/trikGui/qml/RunningCodeComponent.qml
@@ -10,18 +10,18 @@ Rectangle {
     Keys.onPressed: {
         switch (event.key) {
         case Qt.Key_Escape:
-            event.accepted = true
-            break
+            event.accepted = true;
+            break;
         case Qt.Key_PowerOff:
-            RunningCode.abortScript()
-            event.accepted = true
-            break
+            RunningCode.abortScript();
+            event.accepted = true;
+            break;
         case Qt.Key_W:
             if (event.modifiers & Qt.ControlModifier) {
-                RunningCode.abortScript()
-                event.accepted = true
+                RunningCode.abortScript();
+                event.accepted = true;
             }
-            break
+            break;
         }
     }
 


### PR DESCRIPTION
GraphicsWidget dimensions must be set from the very start, before the widget is drawn in the UI. They are required immediately since image scaling in brick.display().showImage() (GuiWorker::showImage) depends on them.