### PR TITLE
Note: possible reader/writer race on mResult (needs further investigation)

### DIFF
--- a/trikControl/src/vectorSensor.cpp
+++ b/trikControl/src/vectorSensor.cpp
@@ -39,7 +39,10 @@ VectorSensor::VectorSensor(const QString &deviceName, const trikKernel::Configur
 	    connect(mIIOFile.data(), &trikHal::IIOFileInterface::newData
 	            , this, [this](QVector<int> reading, const trikKernel::TimeVal &eventTime){
 	                Q_UNUSED(eventTime);
-	                mResult = reading;
+	                // Possible performance issues due to locks, otherwise it works.
+	                // Faults with concurrent reader/writer across threads — see commit message for details.
+	                QWriteLocker locker(&mResultLock);
+	                mResult = std::move(reading);
 	            });
 
 	    QLOG_INFO() << "Starting VectorSensor";
@@ -60,5 +63,7 @@ VectorSensor::Status VectorSensor::status() const
 
 QVector<int> VectorSensor::read() const
 {
+	// Possible performance issues
+	QReadLocker locker(&mResultLock);
 	return mResult;
 }

--- a/trikControl/src/vectorSensor.h
+++ b/trikControl/src/vectorSensor.h
@@ -57,6 +57,7 @@ private:
 
 	QVector<int> mResult {};
 	QScopedPointer<trikHal::IIOFileInterface> mIIOFile;
+	mutable QReadWriteLock mResultLock;
 };
 
 }


### PR DESCRIPTION
This is a hypothesis; the root cause needs further investigation.

The writer updates mResult from one thread, while a reader reads it from another thread. After running for a while, this crash occurs:

    malloc(): unaligned tcache chunk detected
    Segmentation fault (core dumped)

Suspected cause:

1) Assume this is not the first iteration: mResult already points to some region whose refcount is ref = 1.

2) The reader picks up mResult, but hasn't yet called ref() to increment the refcount.

3) Before the reader's increment happens, the writer executes `mResult = std::move(reading)`, which decrements the refcount on the old region. This brings ref to 0 (per step 1), triggering cleanup of that region.

4) During or after cleanup, the reader calls ref() on memory that has already been freed/corrupted.

This looks like a classic use-after-free / TOCTOU race between the refcount increment on the reader side and the pointer reassignment + decrement on the writer side, with no synchronization between them.