### PR TITLE
ci: prefer testing SDK if available, fallback to latest-full

### DIFF
--- a/.github/workflows/trik-toolchain.yml
+++ b/.github/workflows/trik-toolchain.yml
@@ -21,7 +21,8 @@ jobs:
       run:
         shell: bash -l {0} # to force import of ~/.bash_profile
     env:
-      SDK_DOWNLOAD_URL: https://dl.trikset.com/distro/latest-full
+      SDK_LATEST_URL: https://dl.trikset.com/distro/latest-full
+      SDK_TESTING_URL: https://dl.trikset.com/distro/testing
       TRIK_SDK_FILENAME: trik-sdk-x86_64-arm926ejse-toolchain-trik-nodistro.0.sh
 
     steps:
@@ -30,6 +31,16 @@ jobs:
         with:
           path: /opt/trik-sdk
           key: trik_sdk
+
+      - name: Choose SDK source (testing or latest-full)
+        run: |
+            if curl -s -o /dev/null -w '%{http_code}' --head "${SDK_TESTING_URL}/${TRIK_SDK_FILENAME}" | grep -q '^2'; then
+                echo "SDK found in testing, using testing"
+                echo "SDK_DOWNLOAD_URL=${SDK_TESTING_URL}" >> $GITHUB_ENV
+            else
+                echo "SDK not found in testing, using latest-full"
+                echo "SDK_DOWNLOAD_URL=${SDK_LATEST_URL}" >> $GITHUB_ENV
+            fi
 
       - name: Check if TRIK toolchain is up-to-date
         id: trik-toolchain-check


### PR DESCRIPTION
Add a check for the SDK in dl.trikset.com/distro/testing before downloading; use latest-full if it's not found there.