### PR TITLE
Split angularServomotor into 180/270 variants

### DIFF
--- a/tests/kernel-4.14/test-model-config.xml
+++ b/tests/kernel-4.14/test-model-config.xml
@@ -8,22 +8,22 @@ working properly, it tests only that runtime can interact with them).
 	</initScript>
 
 	<S1>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S1>
 	<S2>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S2>
 	<S3>
-		<angularServomotor  />
+		<angularServomotor180  />
 	</S3>
 	<S4>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S4>
 	<S5>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S5>
 	<S6>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S6>
 
 	<A1>

--- a/tests/kernel-4.14/test-system-config.xml
+++ b/tests/kernel-4.14/test-system-config.xml
@@ -179,8 +179,11 @@ equal to its class name.
 	</devicePorts>
 
 	<deviceTypes>
-		<angularServomotor class="servoMotor" min="700000" max="2150000" zero="1425000" stop="0"
-				controlMin="-90" controlMax="90" />
+                <angularServomotor180 class="servoMotor" min="500000" max="2500000" zero="1500000" stop="0"
+		                controlMin="-90" controlMax="90" />
+
+                <angularServomotor270 class="servoMotor" min="500000" max="2500000" zero="1500000" stop="0"
+		                controlMin="-135" controlMax="135" />
 
 		<continuousRotationServomotor class="servoMotor" min="700000" max="2300000" zero="1500000" stop="0"
 				controlMin="-100" controlMax="100" />

--- a/trikControl/configs/kernel-4.14/model-config.xml
+++ b/trikControl/configs/kernel-4.14/model-config.xml
@@ -26,19 +26,19 @@ Note that device, even if listed here, may fail by itself, then it also will not
 
 	<!-- Servomotor or PWM capture ports. -->
 	<S1>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S1>
 	<S2>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S2>
 	<S3>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S3>
 	<S4>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S4>
 	<S5>
-		<angularServomotor />
+		<angularServomotor180 />
 	</S5>
 	<S6>
 		<manipulatorServomotor />

--- a/trikControl/configs/kernel-4.14/system-config.xml
+++ b/trikControl/configs/kernel-4.14/system-config.xml
@@ -185,8 +185,11 @@ equal to its class name.
 	</devicePorts>
 
 	<deviceTypes>
-		<angularServomotor class="servoMotor" min="700000" max="2150000" zero="1425000" stop="0"
-				controlMin="-90" controlMax="90" />
+                <angularServomotor180 class="servoMotor" min="500000" max="2500000" zero="1500000" stop="0"
+		                controlMin="-90" controlMax="90" />
+
+                <angularServomotor270 class="servoMotor" min="500000" max="2500000" zero="1500000" stop="0"
+		                controlMin="-135" controlMax="135" />
 
 		<continuousRotationServomotor class="servoMotor" min="700000" max="2300000" zero="1500000" stop="0"
 				controlMin="-100" controlMax="100" />


### PR DESCRIPTION
The generic angularServomotor option is replaced by angularServomotor180 (180°) and angularServomotor270 (270°).

S1-S5 default to angularServomotor180.

Fix min/max/zero PWM duty cycle values. Current servos in the sets were undershooting (not reaching full rotation range) due to incorrect values.